### PR TITLE
Add NixOS VM integration test framework

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,14 +29,10 @@
         nixosModules.default = ./nix/module;
       };
 
-      perSystem = {
-        config,
-        system,
-        ...
-      }: let
+      perSystem = {system, ...}: let
         pkgs = nixpkgs.legacyPackages.${system};
       in {
-        checks.package-can-build = config.packages.default;
+        checks = import ./nix/tests/integration {inherit pkgs;};
 
         formatter = (treefmt-nix.lib.evalModule pkgs ./treefmt.nix).config.build.wrapper;
 

--- a/nix/tests/integration/base.nix
+++ b/nix/tests/integration/base.nix
@@ -1,0 +1,28 @@
+{pkgs, ...}: {
+  imports = [
+    (import ../../module {
+      inherit pkgs;
+      inherit (pkgs) lib;
+    })
+  ];
+
+  environment.systemPackages = [
+    pkgs.curl
+    pkgs.jq
+    pkgs.sqlite
+  ];
+
+  services = {
+    jellarr = {
+      enable = true;
+      environmentFile = "/tmp/jellarr-env";
+    };
+
+    jellyfin = {
+      enable = true;
+      openFirewall = true;
+    };
+  };
+
+  virtualisation.diskSize = 4096;
+}

--- a/nix/tests/integration/default.nix
+++ b/nix/tests/integration/default.nix
@@ -1,0 +1,8 @@
+{pkgs}: let
+  tests = ["it1"];
+in
+  builtins.listToAttrs (map (name: {
+      inherit name;
+      value = import ./${name}.nix {inherit pkgs;};
+    })
+    tests)

--- a/nix/tests/integration/it1.nix
+++ b/nix/tests/integration/it1.nix
@@ -1,0 +1,43 @@
+{pkgs}:
+pkgs.testers.runNixOSTest {
+  globalTimeout = 600;
+
+  name = "jellarr-it1-preserve-enableMetrics";
+
+  nodes.server = {
+    imports = [
+      ./base.nix
+    ];
+
+    services.jellarr.config = {
+      base_url = "http://localhost:8096";
+      system = {};
+      version = 1;
+    };
+  };
+
+  testScript =
+    # py
+    ''
+      # Arrange
+      print("=== IT1: Testing enableMetrics preservation ===")
+      ${builtins.readFile ./setup.py}
+      setup_jellyfin_with_api_key(server)
+
+      # Act
+      server.succeed("curl -sf -X POST 'http://localhost:8096/System/Configuration' -H 'X-Emby-Token: test' -H 'Content-Type: application/json' -d '{\"EnableMetrics\": true}'")
+      server.succeed("curl -sf 'http://localhost:8096/System/Configuration' -H 'X-Emby-Token: test' | jq -e '.EnableMetrics == true'")
+      print("✓ EnableMetrics set to true")
+
+      print("=== Running jellarr service with config that omits enableMetrics ===")
+      server.succeed("systemctl start jellarr.service")
+      time.sleep(5)
+      server.succeed("systemctl show jellarr.service --property=ExecMainStatus | grep -q 'ExecMainStatus=0'")
+
+      # Assert
+      server.succeed("curl -sf 'http://localhost:8096/System/Configuration' -H 'X-Emby-Token: test' | jq -e '.EnableMetrics == true'")
+      print("✓ EnableMetrics preserved (still true)")
+
+      print("✅ IT1 test passed: enableMetrics preserved when omitted from config")
+    '';
+}

--- a/nix/tests/integration/setup.py
+++ b/nix/tests/integration/setup.py
@@ -1,0 +1,45 @@
+import time
+
+
+def setup_jellyfin_with_api_key(server):
+    print("=== Starting the VM / Server ===")
+    server.start()
+    server.wait_for_unit("jellyfin.service")
+    server.wait_for_open_port(8096)
+
+    print("=== Setting up API key ===")
+    time.sleep(15)
+    server.succeed("test -f /var/lib/jellyfin/data/jellyfin.db")
+    server.succeed("systemctl stop jellyfin.service")
+    time.sleep(3)
+    server.succeed(
+        "sqlite3 /var/lib/jellyfin/data/jellyfin.db \"INSERT OR IGNORE INTO ApiKeys (AccessToken, Name, DateCreated, DateLastActivity) VALUES ('test', 'jellarr-test', datetime('now'), datetime('now'));\""
+    )
+    server.succeed("echo 'JELLARR_API_KEY=test' > /tmp/jellarr-env")
+    server.succeed("systemctl start jellyfin.service")
+    server.wait_for_unit("jellyfin.service")
+    server.wait_for_open_port(8096)
+
+    print("=== Waiting for Jellyfin API ===")
+    for i in range(30):
+        try:
+            server.succeed("curl -sf 'http://localhost:8096/System/Info/Public'")
+            print("✓ Jellyfin public API ready")
+            break
+        except:
+            time.sleep(2)
+    else:
+        raise Exception("Jellyfin public API never became ready")
+
+    print("=== Waiting for authenticated API ===")
+    for i in range(30):
+        try:
+            server.succeed(
+                "curl -sf 'http://localhost:8096/System/Configuration' -H 'X-Emby-Token: test'"
+            )
+            print("✓ Jellyfin authenticated API ready")
+            break
+        except:
+            time.sleep(2)
+    else:
+        raise Exception("Jellyfin authenticated API never became ready")

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -30,5 +30,13 @@ _: {
       ];
       priority = 50;
     };
+
+    black = {
+      enable = true;
+      includes = [
+        "*.py"
+      ];
+      priority = 60;
+    };
   };
 }


### PR DESCRIPTION
This implements comprehensive integration testing infrastructure to validate jellarr's declarative behavior against real Jellyfin instances.

## Key Features

- **NixOS VM test framework**: Uses pkgs.testers.runNixOSTest for isolated testing
- **Automated Jellyfin setup**: Fresh instances with API key injection via SQLite
- **Data-driven test registration**: Add tests by updating simple list
- **IT1 implementation**: Validates enableMetrics preservation when omitted
- **Scalable architecture**: Clean separation with base.nix and setup.py utilities

## Architecture

- `nix/tests/integration/default.nix` - Test registry with data-driven approach
- `nix/tests/integration/base.nix` - Common VM configuration
- `nix/tests/integration/setup.py` - Reusable Python utilities
- `nix/tests/integration/it1.nix` - First integration test (enableMetrics preservation)
- `treefmt.nix` - Added Python black formatter integration

Tests run via `nix flake check` with 600-second timeout for complex VM operations. Foundation ready for IT2-IT10 covering all declarative behavior scenarios.

Resolves #8