### PR TITLE
Fixup jellarr.service lifecycle

### DIFF
--- a/nix/module/config.nix
+++ b/nix/module/config.nix
@@ -43,10 +43,12 @@ in {
             ExecStart = lib.getExe pkg;
             Group = cfg.group;
             Type = "oneshot";
+            RemainAfterExit = true;
             User = cfg.user;
             WorkingDirectory = cfg.dataDir;
           };
           wants = ["network-online.target"];
+          wantedBy = ["multi-user.target"];
         };
 
         timers.jellarr = {


### PR DESCRIPTION
Currently I find when I deploy Jellarr, nothing happens unless I manually [re]start the service. I guess eventually if I waited for the timer it would work, but that's not in line with my expectation for deploying Nix services.

Add it to the wants for multi-user.target so that it is started automatically as soon as it exists. Also, set RemainAfterExit so that systemd considers the service to be "alive". This means that when the configuration is changed, the NixOS configuration switch logic will restart it, immediately deploying the updated configuration.