### PR TITLE
docs: Update jellarr input version in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Add to your `flake.nix`:
 
 ```nix
 {
-  inputs.jellarr.url = "github:venkyr77/jellarr/v0.0.1";
+  inputs.jellarr.url = "github:venkyr77/jellarr";
 
   outputs = { self, nixpkgs, jellarr, ... }: {
     nixosConfigurations.myhost = nixpkgs.lib.nixosSystem {


### PR DESCRIPTION
This example uses 0.0.1 and also enables the bootstrap feature, but that feature did not exist in that version.