### PR TITLE
Feat/simplify apply diff

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -44,7 +44,7 @@ pkgs.stdenvNoCC.mkDerivation (finalAttrs: {
 
   pnpmDeps = pkgs.pnpm.fetchDeps {
     fetcherVersion = 1;
-    hash = "sha256-EFshNgnzsgnJnXuhdbyZKsMQ2W7LWA58jNQEzJ7TTwU=";
+    hash = "sha256-E401r/pYg2Z+Fsk2rGrmPPZ4A+AJ7aSByTL8xaO3uHs=";
     inherit (finalAttrs) pname src version;
   };
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "commander": "^14.0.2",
     "dotenv": "^17.2.3",
     "fast-equals": "^5.3.2",
+    "json-diff-ts": "^4.8.2",
     "openapi-fetch": "^0.15.0",
     "undici": "^7.16.0",
     "yaml": "^2.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
       fast-equals:
         specifier: ^5.3.2
         version: 5.3.2
+      json-diff-ts:
+        specifier: ^4.8.2
+        version: 4.8.2
       openapi-fetch:
         specifier: ^0.15.0
         version: 0.15.0
@@ -1333,6 +1336,12 @@ packages:
         integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==,
       }
 
+  json-diff-ts@4.8.2:
+    resolution:
+      {
+        integrity: sha512-7LgOTnfK5XnBs0o0AtHTkry5QGZT7cSlAgu5GtiomUeoHqOavAUDcONNm/bCe4Lapt0AHnaidD5iSE+ItvxKkA==,
+      }
+
   json-schema-traverse@0.4.1:
     resolution:
       {
@@ -2563,6 +2572,8 @@ snapshots:
       argparse: 2.0.1
 
   json-buffer@3.0.1: {}
+
+  json-diff-ts@4.8.2: {}
 
   json-schema-traverse@0.4.1: {}
 

--- a/src/apply/branding-options.ts
+++ b/src/apply/branding-options.ts
@@ -10,8 +10,11 @@ export function calculateBrandingOptionsDiff(
   current: BrandingOptionsDtoSchema,
   desired: BrandingOptionsConfig,
 ): BrandingOptionsDtoSchema | undefined {
+  const next: BrandingOptionsDtoSchema =
+    mapBrandingOptionsConfigToSchema(desired);
+
   const patch: IChange[] = new ChangeSetBuilder(
-    diff(current, mapBrandingOptionsConfigToSchema(desired), {
+    diff(current, next, {
       treatTypeChangeAsReplace: false,
     }),
   )

--- a/src/apply/branding-options.ts
+++ b/src/apply/branding-options.ts
@@ -3,82 +3,24 @@ import type { BrandingOptionsDtoSchema } from "../types/schema/branding-options"
 import { mapBrandingOptionsConfigToSchema } from "../mappers/branding-options";
 import type { JellyfinClient } from "../api/jellyfin.types";
 import { logger } from "../lib/logger";
-
-function hasLoginDisclaimerChanged(
-  current: BrandingOptionsDtoSchema,
-  desired: BrandingOptionsConfig,
-): boolean {
-  if (desired.loginDisclaimer === undefined) return false;
-  const currentValue: string = current.LoginDisclaimer ?? "";
-  const desiredValue: string = desired.loginDisclaimer ?? "";
-  return currentValue !== desiredValue;
-}
-
-function hasCustomCssChanged(
-  current: BrandingOptionsDtoSchema,
-  desired: BrandingOptionsConfig,
-): boolean {
-  if (desired.customCss === undefined) return false;
-  const currentValue: string = current.CustomCss ?? "";
-  const desiredValue: string = desired.customCss ?? "";
-  return currentValue !== desiredValue;
-}
-
-function hasSplashscreenEnabledChanged(
-  current: BrandingOptionsDtoSchema,
-  desired: BrandingOptionsConfig,
-): boolean {
-  if (desired.splashscreenEnabled === undefined) return false;
-  const currentValue: boolean = current.SplashscreenEnabled ?? false;
-  return currentValue !== desired.splashscreenEnabled;
-}
+import { diff, applyChangeset, type IChange, Operation } from "json-diff-ts";
 
 export function calculateBrandingOptionsDiff(
   current: BrandingOptionsDtoSchema,
   desired: BrandingOptionsConfig,
 ): BrandingOptionsDtoSchema | undefined {
-  const hasChanges: boolean =
-    hasLoginDisclaimerChanged(current, desired) ||
-    hasCustomCssChanged(current, desired) ||
-    hasSplashscreenEnabledChanged(current, desired);
+  const patch: IChange[] = diff(
+    current,
+    mapBrandingOptionsConfigToSchema(desired),
+    { treatTypeChangeAsReplace: false },
+  ).filter((change: IChange) => change.type !== Operation.REMOVE);
 
-  if (!hasChanges) return undefined;
-
-  if (hasLoginDisclaimerChanged(current, desired)) {
-    logger.info(
-      `LoginDisclaimer changed: ${String(current.LoginDisclaimer)} → ${String(desired.loginDisclaimer)}`,
-    );
+  if (patch.length != 0) {
+    logger.info(JSON.stringify(patch));
+    return applyChangeset(current, patch) as BrandingOptionsDtoSchema;
   }
 
-  if (hasCustomCssChanged(current, desired)) {
-    logger.info(
-      `CustomCss changed: ${String(current.CustomCss)} → ${String(desired.customCss)}`,
-    );
-  }
-
-  if (hasSplashscreenEnabledChanged(current, desired)) {
-    logger.info(
-      `SplashscreenEnabled changed: ${String(current.SplashscreenEnabled)} → ${String(desired.splashscreenEnabled)}`,
-    );
-  }
-
-  const patch: Partial<BrandingOptionsDtoSchema> =
-    mapBrandingOptionsConfigToSchema(desired);
-  const out: BrandingOptionsDtoSchema = { ...current };
-
-  if ("LoginDisclaimer" in patch) {
-    out.LoginDisclaimer = patch.LoginDisclaimer;
-  }
-
-  if ("CustomCss" in patch) {
-    out.CustomCss = patch.CustomCss;
-  }
-
-  if ("SplashscreenEnabled" in patch) {
-    out.SplashscreenEnabled = patch.SplashscreenEnabled;
-  }
-
-  return out;
+  return undefined;
 }
 
 export async function applyBrandingOptions(
@@ -86,5 +28,6 @@ export async function applyBrandingOptions(
   updatedSchema: BrandingOptionsDtoSchema | undefined,
 ): Promise<void> {
   if (!updatedSchema) return;
+
   await client.updateBrandingConfiguration(updatedSchema);
 }

--- a/src/apply/encoding-options.ts
+++ b/src/apply/encoding-options.ts
@@ -10,9 +10,11 @@ export function calculateEncodingDiff(
   current: EncodingOptionsSchema,
   desired: EncodingOptionsConfig,
 ): EncodingOptionsSchema | undefined {
+  const next: EncodingOptionsSchema = mapEncodingOptionsConfigToSchema(desired);
+
   const patch: IChange[] = [
     ...new ChangeSetBuilder(
-      diff(current, mapEncodingOptionsConfigToSchema(desired), {
+      diff(current, next, {
         keysToSkip: ["HardwareDecodingCodecs"],
         treatTypeChangeAsReplace: false,
       }),
@@ -21,7 +23,7 @@ export function calculateEncodingDiff(
       .toArray(),
 
     ...new ChangeSetBuilder(
-      diff(current, mapEncodingOptionsConfigToSchema(desired), {
+      diff(current, next, {
         embeddedObjKeys: { HardwareDecodingCodecs: "$value" },
         treatTypeChangeAsReplace: false,
       }),
@@ -43,9 +45,7 @@ export async function applyEncoding(
   client: JellyfinClient,
   updatedSchema: EncodingOptionsSchema | undefined,
 ): Promise<void> {
-  if (!updatedSchema) {
-    return;
-  }
+  if (!updatedSchema) return;
 
   await client.updateEncodingConfiguration(updatedSchema);
 }

--- a/src/apply/encoding-options.ts
+++ b/src/apply/encoding-options.ts
@@ -1,281 +1,41 @@
-import { deepEqual } from "fast-equals";
 import { logger } from "../lib/logger";
 import type { JellyfinClient } from "../api/jellyfin.types";
 import { mapEncodingOptionsConfigToSchema } from "../mappers/encoding-options";
 import { type EncodingOptionsConfig } from "../types/config/encoding-options";
 import { type EncodingOptionsSchema } from "../types/schema/encoding-options";
-
-function hasEnableHardwareEncodingChanged(
-  current: EncodingOptionsSchema,
-  desired: EncodingOptionsConfig,
-): boolean {
-  if (desired.enableHardwareEncoding === undefined) return false;
-
-  const cur: boolean = Boolean(current.EnableHardwareEncoding);
-  const next: boolean = desired.enableHardwareEncoding;
-
-  return cur !== next;
-}
-
-function hasHardwareAccelerationTypeChanged(
-  current: EncodingOptionsSchema,
-  desired: EncodingOptionsConfig,
-): boolean {
-  if (desired.hardwareAccelerationType === undefined) return false;
-
-  const cur: string = current.HardwareAccelerationType ?? "none";
-  const next: string = desired.hardwareAccelerationType;
-
-  return cur !== next;
-}
-
-function hasHardwareDecodingCodecsChanged(
-  current: EncodingOptionsSchema,
-  desired: EncodingOptionsConfig,
-): boolean {
-  if (desired.hardwareDecodingCodecs === undefined) return false;
-
-  const cur: string[] = current.HardwareDecodingCodecs ?? [];
-  const next: string[] = desired.hardwareDecodingCodecs;
-
-  return !deepEqual([...cur].sort(), [...next].sort());
-}
-
-function hasEnableDecodingColorDepth10HevcChanged(
-  current: EncodingOptionsSchema,
-  desired: EncodingOptionsConfig,
-): boolean {
-  if (desired.enableDecodingColorDepth10Hevc === undefined) return false;
-
-  const cur: boolean = Boolean(current.EnableDecodingColorDepth10Hevc);
-  const next: boolean = desired.enableDecodingColorDepth10Hevc;
-
-  return cur !== next;
-}
-
-function hasEnableDecodingColorDepth10Vp9Changed(
-  current: EncodingOptionsSchema,
-  desired: EncodingOptionsConfig,
-): boolean {
-  if (desired.enableDecodingColorDepth10Vp9 === undefined) return false;
-
-  const cur: boolean = Boolean(current.EnableDecodingColorDepth10Vp9);
-  const next: boolean = desired.enableDecodingColorDepth10Vp9;
-
-  return cur !== next;
-}
-
-function hasEnableDecodingColorDepth10HevcRextChanged(
-  current: EncodingOptionsSchema,
-  desired: EncodingOptionsConfig,
-): boolean {
-  if (desired.enableDecodingColorDepth10HevcRext === undefined) return false;
-
-  const cur: boolean = Boolean(current.EnableDecodingColorDepth10HevcRext);
-  const next: boolean = desired.enableDecodingColorDepth10HevcRext;
-
-  return cur !== next;
-}
-
-function hasEnableDecodingColorDepth12HevcRextChanged(
-  current: EncodingOptionsSchema,
-  desired: EncodingOptionsConfig,
-): boolean {
-  if (desired.enableDecodingColorDepth12HevcRext === undefined) return false;
-
-  const cur: boolean = Boolean(current.EnableDecodingColorDepth12HevcRext);
-  const next: boolean = desired.enableDecodingColorDepth12HevcRext;
-
-  return cur !== next;
-}
-
-function hasVaapiDeviceChanged(
-  current: EncodingOptionsSchema,
-  desired: EncodingOptionsConfig,
-): boolean {
-  if (desired.vaapiDevice === undefined) return false;
-
-  const cur: string = current.VaapiDevice ?? "";
-  const next: string = desired.vaapiDevice;
-
-  return cur !== next;
-}
-
-function hasQsvDeviceChanged(
-  current: EncodingOptionsSchema,
-  desired: EncodingOptionsConfig,
-): boolean {
-  if (desired.qsvDevice === undefined) return false;
-
-  const cur: string = current.QsvDevice ?? "";
-  const next: string = desired.qsvDevice;
-
-  return cur !== next;
-}
-
-function hasAllowHevcEncodingChanged(
-  current: EncodingOptionsSchema,
-  desired: EncodingOptionsConfig,
-): boolean {
-  if (desired.allowHevcEncoding === undefined) return false;
-
-  const cur: boolean = Boolean(current.AllowHevcEncoding);
-  const next: boolean = desired.allowHevcEncoding;
-
-  return cur !== next;
-}
-
-function hasAllowAv1EncodingChanged(
-  current: EncodingOptionsSchema,
-  desired: EncodingOptionsConfig,
-): boolean {
-  if (desired.allowAv1Encoding === undefined) return false;
-
-  const cur: boolean = Boolean(current.AllowAv1Encoding);
-  const next: boolean = desired.allowAv1Encoding;
-
-  return cur !== next;
-}
+import { applyChangeset, diff, type IChange } from "json-diff-ts";
+import { ChangeSetBuilder } from "../lib/changeset";
 
 export function calculateEncodingDiff(
   current: EncodingOptionsSchema,
   desired: EncodingOptionsConfig,
 ): EncodingOptionsSchema | undefined {
-  const patch: Partial<EncodingOptionsSchema> =
-    mapEncodingOptionsConfigToSchema(desired);
+  const patch: IChange[] = [
+    ...new ChangeSetBuilder(
+      diff(current, mapEncodingOptionsConfigToSchema(desired), {
+        keysToSkip: ["HardwareDecodingCodecs"],
+        treatTypeChangeAsReplace: false,
+      }),
+    )
+      .withoutRemoves()
+      .toArray(),
+    ...new ChangeSetBuilder(
+      diff(current, mapEncodingOptionsConfigToSchema(desired), {
+        embeddedObjKeys: { HardwareDecodingCodecs: "$value" },
+        treatTypeChangeAsReplace: false,
+      }),
+    )
+      .withoutRemoves()
+      .withKey("HardwareDecodingCodecs")
+      .toArray(),
+  ];
 
-  const hasChanges: boolean =
-    hasEnableHardwareEncodingChanged(current, desired) ||
-    hasHardwareAccelerationTypeChanged(current, desired) ||
-    hasHardwareDecodingCodecsChanged(current, desired) ||
-    hasEnableDecodingColorDepth10HevcChanged(current, desired) ||
-    hasEnableDecodingColorDepth10Vp9Changed(current, desired) ||
-    hasEnableDecodingColorDepth10HevcRextChanged(current, desired) ||
-    hasEnableDecodingColorDepth12HevcRextChanged(current, desired) ||
-    hasVaapiDeviceChanged(current, desired) ||
-    hasQsvDeviceChanged(current, desired) ||
-    hasAllowHevcEncodingChanged(current, desired) ||
-    hasAllowAv1EncodingChanged(current, desired);
-
-  if (!hasChanges) {
-    return undefined;
+  if (patch.length != 0) {
+    logger.info(JSON.stringify(patch));
+    return applyChangeset(current, patch) as EncodingOptionsSchema;
   }
 
-  if (hasEnableHardwareEncodingChanged(current, desired)) {
-    logger.info(
-      `EnableHardwareEncoding changed: ${String(current.EnableHardwareEncoding)} → ${String(desired.enableHardwareEncoding)}`,
-    );
-  }
-
-  if (hasHardwareAccelerationTypeChanged(current, desired)) {
-    logger.info(
-      `HardwareAccelerationType changed: ${current.HardwareAccelerationType ?? "none"} → ${desired.hardwareAccelerationType ?? "none"}`,
-    );
-  }
-
-  if (hasHardwareDecodingCodecsChanged(current, desired)) {
-    logger.info(
-      `HardwareDecodingCodecs changed: [${(current.HardwareDecodingCodecs ?? []).join(", ")}] → [${desired.hardwareDecodingCodecs?.join(", ") ?? ""}]`,
-    );
-  }
-
-  if (hasEnableDecodingColorDepth10HevcChanged(current, desired)) {
-    logger.info(
-      `EnableDecodingColorDepth10Hevc changed: ${String(current.EnableDecodingColorDepth10Hevc)} → ${String(desired.enableDecodingColorDepth10Hevc)}`,
-    );
-  }
-
-  if (hasEnableDecodingColorDepth10Vp9Changed(current, desired)) {
-    logger.info(
-      `EnableDecodingColorDepth10Vp9 changed: ${String(current.EnableDecodingColorDepth10Vp9)} → ${String(desired.enableDecodingColorDepth10Vp9)}`,
-    );
-  }
-
-  if (hasEnableDecodingColorDepth10HevcRextChanged(current, desired)) {
-    logger.info(
-      `EnableDecodingColorDepth10HevcRext changed: ${String(current.EnableDecodingColorDepth10HevcRext)} → ${String(desired.enableDecodingColorDepth10HevcRext)}`,
-    );
-  }
-
-  if (hasEnableDecodingColorDepth12HevcRextChanged(current, desired)) {
-    logger.info(
-      `EnableDecodingColorDepth12HevcRext changed: ${String(current.EnableDecodingColorDepth12HevcRext)} → ${String(desired.enableDecodingColorDepth12HevcRext)}`,
-    );
-  }
-
-  if (hasVaapiDeviceChanged(current, desired)) {
-    logger.info(
-      `VaapiDevice changed: "${current.VaapiDevice ?? ""}" → "${desired.vaapiDevice ?? ""}"`,
-    );
-  }
-
-  if (hasQsvDeviceChanged(current, desired)) {
-    logger.info(
-      `QsvDevice changed: "${current.QsvDevice ?? ""}" → "${desired.qsvDevice ?? ""}"`,
-    );
-  }
-
-  if (hasAllowHevcEncodingChanged(current, desired)) {
-    logger.info(
-      `AllowHevcEncoding changed: ${String(current.AllowHevcEncoding)} → ${String(desired.allowHevcEncoding)}`,
-    );
-  }
-
-  if (hasAllowAv1EncodingChanged(current, desired)) {
-    logger.info(
-      `AllowAv1Encoding changed: ${String(current.AllowAv1Encoding)} → ${String(desired.allowAv1Encoding)}`,
-    );
-  }
-
-  const out: EncodingOptionsSchema = { ...current };
-
-  if ("EnableHardwareEncoding" in patch) {
-    out.EnableHardwareEncoding = patch.EnableHardwareEncoding;
-  }
-
-  if ("HardwareAccelerationType" in patch) {
-    out.HardwareAccelerationType = patch.HardwareAccelerationType;
-  }
-
-  if ("HardwareDecodingCodecs" in patch) {
-    out.HardwareDecodingCodecs = patch.HardwareDecodingCodecs;
-  }
-
-  if ("EnableDecodingColorDepth10Hevc" in patch) {
-    out.EnableDecodingColorDepth10Hevc = patch.EnableDecodingColorDepth10Hevc;
-  }
-
-  if ("EnableDecodingColorDepth10Vp9" in patch) {
-    out.EnableDecodingColorDepth10Vp9 = patch.EnableDecodingColorDepth10Vp9;
-  }
-
-  if ("EnableDecodingColorDepth10HevcRext" in patch) {
-    out.EnableDecodingColorDepth10HevcRext =
-      patch.EnableDecodingColorDepth10HevcRext;
-  }
-
-  if ("EnableDecodingColorDepth12HevcRext" in patch) {
-    out.EnableDecodingColorDepth12HevcRext =
-      patch.EnableDecodingColorDepth12HevcRext;
-  }
-
-  if ("VaapiDevice" in patch) {
-    out.VaapiDevice = patch.VaapiDevice;
-  }
-
-  if ("QsvDevice" in patch) {
-    out.QsvDevice = patch.QsvDevice;
-  }
-
-  if ("AllowHevcEncoding" in patch) {
-    out.AllowHevcEncoding = patch.AllowHevcEncoding;
-  }
-
-  if ("AllowAv1Encoding" in patch) {
-    out.AllowAv1Encoding = patch.AllowAv1Encoding;
-  }
-
-  return out;
+  return undefined;
 }
 
 export async function applyEncoding(

--- a/src/apply/encoding-options.ts
+++ b/src/apply/encoding-options.ts
@@ -28,8 +28,8 @@ export function calculateEncodingDiff(
         treatTypeChangeAsReplace: false,
       }),
     )
-      .withoutRemoves()
       .withKey("HardwareDecodingCodecs")
+      .withoutRemoves()
       .toArray(),
   ];
 

--- a/src/apply/encoding-options.ts
+++ b/src/apply/encoding-options.ts
@@ -19,6 +19,7 @@ export function calculateEncodingDiff(
     )
       .withoutRemoves()
       .toArray(),
+
     ...new ChangeSetBuilder(
       diff(current, mapEncodingOptionsConfigToSchema(desired), {
         embeddedObjKeys: { HardwareDecodingCodecs: "$value" },

--- a/src/apply/library.ts
+++ b/src/apply/library.ts
@@ -50,6 +50,7 @@ export async function applyLibrary(
 
   for (const virtualFolder of virtualFoldersToAdd) {
     const name: string = virtualFolder.Name as string;
+
     const collectionType: CollectionTypeSchema =
       virtualFolder.CollectionType as CollectionTypeSchema;
 

--- a/src/apply/library.ts
+++ b/src/apply/library.ts
@@ -21,8 +21,12 @@ export function calculateLibraryDiff(
     return undefined;
   }
 
+  const next: VirtualFolderInfoSchema[] = desired.map(
+    mapVirtualFolderConfigToSchema,
+  );
+
   const patch: IChange[] = new ChangeSetBuilder(
-    diff(current, desired.map(mapVirtualFolderConfigToSchema), {
+    diff(current, next, {
       embeddedObjKeys: { ".": "Name" },
       treatTypeChangeAsReplace: false,
     }),
@@ -44,9 +48,7 @@ export async function applyLibrary(
   client: JellyfinClient,
   virtualFoldersToAdd: VirtualFolderInfoSchema[] | undefined,
 ): Promise<void> {
-  if (!virtualFoldersToAdd) {
-    return;
-  }
+  if (!virtualFoldersToAdd) return;
 
   for (const virtualFolder of virtualFoldersToAdd) {
     const name: string = virtualFolder.Name as string;

--- a/src/apply/library.ts
+++ b/src/apply/library.ts
@@ -1,84 +1,65 @@
-import { deepEqual } from "fast-equals";
 import { logger } from "../lib/logger";
+import { ChangeSetBuilder } from "../lib/changeset";
 import type { JellyfinClient } from "../api/jellyfin.types";
-import type {
-  LibraryConfig,
-  VirtualFolderConfig,
-} from "../types/config/library";
+import type { VirtualFolderConfig } from "../types/config/library";
 import type {
   VirtualFolderInfoSchema,
   CollectionTypeSchema,
   AddVirtualFolderDtoSchema,
 } from "../types/schema/library";
-import { mapVirtualFolderConfigToAddVirtualFolderDto } from "../mappers/library";
+import {
+  mapVirtualFolderConfigToSchema,
+  mapVirtualFolderInfoSchemaToAddVirtualFolderDtoSchema,
+} from "../mappers/library";
+import { applyChangeset, diff, type IChange } from "json-diff-ts";
 
 export function calculateLibraryDiff(
-  currentVirtualFolders: VirtualFolderInfoSchema[],
-  desired: LibraryConfig,
-): LibraryConfig | undefined {
-  if (!desired.virtualFolders || desired.virtualFolders.length === 0) {
+  current: VirtualFolderInfoSchema[],
+  desired: VirtualFolderConfig[],
+): VirtualFolderInfoSchema[] | undefined {
+  if (desired.length === 0) {
     return undefined;
   }
 
-  const virtualFoldersToCreate: VirtualFolderConfig[] = [];
-  let hasUpdates: boolean = false;
+  const patch: IChange[] = new ChangeSetBuilder(
+    diff(current, desired.map(mapVirtualFolderConfigToSchema), {
+      embeddedObjKeys: { ".": "Name" },
+      treatTypeChangeAsReplace: false,
+    }),
+  )
+    .atomize()
+    .withoutRemoves()
+    .withoutUpdates()
+    .toArray();
 
-  for (const desiredVF of desired.virtualFolders) {
-    const existingVF: VirtualFolderInfoSchema | undefined =
-      currentVirtualFolders.find(
-        (vf: VirtualFolderInfoSchema) => vf.Name === desiredVF.name,
-      );
-
-    if (!existingVF) {
-      virtualFoldersToCreate.push(desiredVF);
-    } else {
-      const currentLocations: string[] = existingVF.Locations ?? [];
-      const desiredLocations: string[] = desiredVF.libraryOptions.pathInfos.map(
-        (p: { path: string }) => p.path,
-      );
-
-      if (
-        !deepEqual([...currentLocations].sort(), [...desiredLocations].sort())
-      ) {
-        hasUpdates = true;
-        logger.warn(
-          `Virtual folder ${desiredVF.name} exists but locations differ - updates not yet supported`,
-        );
-        logger.warn(`  Current: [${currentLocations.join(", ")}]`);
-        logger.warn(`  Desired: [${desiredLocations.join(", ")}]`);
-      }
-    }
+  if (patch.length !== 0) {
+    logger.info(JSON.stringify(patch));
+    return applyChangeset([], patch) as VirtualFolderInfoSchema[];
   }
 
-  if (virtualFoldersToCreate.length === 0 && !hasUpdates) {
-    return undefined;
-  }
-
-  return { virtualFolders: virtualFoldersToCreate };
+  return undefined;
 }
 
 export async function applyLibrary(
   client: JellyfinClient,
-  libraryConfig: LibraryConfig | undefined,
+  virtualFoldersToAdd: VirtualFolderInfoSchema[] | undefined,
 ): Promise<void> {
-  if (!libraryConfig?.virtualFolders) {
+  if (!virtualFoldersToAdd) {
     return;
   }
 
-  for (const virtualFolder of libraryConfig.virtualFolders) {
-    logger.info(`Creating virtual folder: ${virtualFolder.name}`);
+  for (const virtualFolder of virtualFoldersToAdd) {
+    const name: string = virtualFolder.Name as string;
+    const collectionType: CollectionTypeSchema =
+      virtualFolder.CollectionType as CollectionTypeSchema;
+
+    logger.info(`Creating virtual folder: ${name}`);
 
     const addVirtualFolderDto: AddVirtualFolderDtoSchema =
-      mapVirtualFolderConfigToAddVirtualFolderDto(virtualFolder);
+      mapVirtualFolderInfoSchemaToAddVirtualFolderDtoSchema(virtualFolder);
 
-    await client.addVirtualFolder(
-      virtualFolder.name,
-      virtualFolder.collectionType as CollectionTypeSchema,
-      addVirtualFolderDto,
-    );
+    await client.addVirtualFolder(name, collectionType, addVirtualFolderDto);
 
-    logger.info(
-      `✓ Created virtual folder: ${virtualFolder.name} (${virtualFolder.collectionType})`,
-    );
+    logger.info(`✓ Created virtual folder: ${name} (${collectionType})`);
   }
 }

--- a/src/apply/system.ts
+++ b/src/apply/system.ts
@@ -57,9 +57,7 @@ export async function applySystem(
   client: JellyfinClient,
   updatedSchema: ServerConfigurationSchema | undefined,
 ): Promise<void> {
-  if (!updatedSchema) {
-    return;
-  }
+  if (!updatedSchema) return;
 
   await client.updateSystemConfiguration(updatedSchema);
 }

--- a/src/apply/system.ts
+++ b/src/apply/system.ts
@@ -17,8 +17,8 @@ export function calculateSystemDiff(
     ...new ChangeSetBuilder(
       diff(current, next, { treatTypeChangeAsReplace: false }),
     )
-      .withoutRemoves()
       .withKey("EnableMetrics")
+      .withoutRemoves()
       .atomize()
       .toArray(),
 
@@ -28,16 +28,16 @@ export function calculateSystemDiff(
         treatTypeChangeAsReplace: false,
       }),
     )
-      .withoutRemoves()
       .withKey("PluginRepositories")
+      .withoutRemoves()
       .atomize()
       .toArray(),
 
     ...new ChangeSetBuilder(
       diff(current, next, { treatTypeChangeAsReplace: false }),
     )
-      .withoutRemoves()
       .withKey("TrickplayOptions")
+      .withoutRemoves()
       .atomize()
       .withoutRemoves()
       .toArray(),

--- a/src/apply/system.ts
+++ b/src/apply/system.ts
@@ -1,140 +1,56 @@
-import { deepEqual } from "fast-equals";
 import { logger } from "../lib/logger";
+import { ChangeSetBuilder, AtomicChangeSetBuilder } from "../lib/changeset";
 import type { JellyfinClient } from "../api/jellyfin.types";
-import {
-  fromPluginRepositorySchemas,
-  mapSystemConfigurationConfigToSchema,
-} from "../mappers/system";
+import { mapSystemConfigurationConfigToSchema } from "../mappers/system";
 import { type SystemConfig } from "../types/config/system";
-import {
-  type PluginRepositoryConfig,
-  type TrickplayOptionsConfig,
-} from "../types/config/system";
-import {
-  type ServerConfigurationSchema,
-  type TrickplayOptionsSchema,
-} from "../types/schema/system";
-
-function hasEnableMetricsChanged(
-  current: ServerConfigurationSchema,
-  desired: SystemConfig,
-): boolean {
-  if (desired.enableMetrics === undefined) return false;
-
-  const cur: boolean = Boolean(current.EnableMetrics);
-  const next: boolean = desired.enableMetrics;
-
-  return cur !== next;
-}
-
-function arePluginRepositoryConfigsEqual(
-  a: PluginRepositoryConfig[],
-  b: PluginRepositoryConfig[],
-): boolean {
-  const sortByNameAndUrl: (
-    repos: PluginRepositoryConfig[],
-  ) => PluginRepositoryConfig[] = (
-    repos: PluginRepositoryConfig[],
-  ): PluginRepositoryConfig[] =>
-    [...repos].sort(
-      (a: PluginRepositoryConfig, b: PluginRepositoryConfig) =>
-        a.name.localeCompare(b.name) || a.url.localeCompare(b.url),
-    );
-
-  return deepEqual(sortByNameAndUrl(a), sortByNameAndUrl(b));
-}
-
-function hasPluginRepositoriesChanged(
-  current: ServerConfigurationSchema,
-  desired: SystemConfig,
-): boolean {
-  if (desired.pluginRepositories === undefined) return false;
-
-  return !arePluginRepositoryConfigsEqual(
-    fromPluginRepositorySchemas(current.PluginRepositories),
-    desired.pluginRepositories,
-  );
-}
-
-function hasTrickplayOptionsChanged(
-  current: ServerConfigurationSchema,
-  desired: SystemConfig,
-): boolean {
-  const cfg: TrickplayOptionsConfig | undefined = desired.trickplayOptions;
-
-  if (!cfg) return false;
-
-  const cur: TrickplayOptionsSchema = current.TrickplayOptions ?? {};
-
-  if ("enableHwAcceleration" in cfg) {
-    const before: boolean | null = cur.EnableHwAcceleration ?? null;
-    const after: boolean | null = cfg.enableHwAcceleration ?? null;
-    if (before !== after) {
-      return true;
-    }
-  }
-
-  if ("enableHwEncoding" in cfg) {
-    const before: boolean | null = cur.EnableHwEncoding ?? null;
-    const after: boolean | null = cfg.enableHwEncoding ?? null;
-    if (before !== after) {
-      return true;
-    }
-  }
-
-  return false;
-}
+import { type ServerConfigurationSchema } from "../types/schema/system";
+import { diff, applyChangeset, type IChange } from "json-diff-ts";
 
 export function calculateSystemDiff(
   current: ServerConfigurationSchema,
   desired: SystemConfig,
 ): ServerConfigurationSchema | undefined {
-  const patch: Partial<ServerConfigurationSchema> =
+  const next: ServerConfigurationSchema =
     mapSystemConfigurationConfigToSchema(desired);
 
-  const hasChanges: boolean =
-    hasEnableMetricsChanged(current, desired) ||
-    hasPluginRepositoriesChanged(current, desired) ||
-    hasTrickplayOptionsChanged(current, desired);
+  const patch: IChange[] = new AtomicChangeSetBuilder([
+    ...new ChangeSetBuilder(
+      diff(current, next, { treatTypeChangeAsReplace: false }),
+    )
+      .withoutRemoves()
+      .withKey("EnableMetrics")
+      .atomize()
+      .toArray(),
 
-  if (!hasChanges) {
-    return undefined;
+    ...new ChangeSetBuilder(
+      diff(current, next, {
+        embeddedObjKeys: { ".": "Name" },
+        treatTypeChangeAsReplace: false,
+      }),
+    )
+      .withoutRemoves()
+      .withKey("PluginRepositories")
+      .atomize()
+      .toArray(),
+
+    ...new ChangeSetBuilder(
+      diff(current, next, { treatTypeChangeAsReplace: false }),
+    )
+      .withoutRemoves()
+      .withKey("TrickplayOptions")
+      .atomize()
+      .withoutRemoves()
+      .toArray(),
+  ])
+    .unatomize()
+    .toArray();
+
+  if (patch.length != 0) {
+    logger.info(JSON.stringify(patch));
+    return applyChangeset(current, patch) as ServerConfigurationSchema;
   }
 
-  if (hasEnableMetricsChanged(current, desired)) {
-    logger.info(
-      `EnableMetrics changed: ${String(current.EnableMetrics)} → ${String(desired.enableMetrics)}`,
-    );
-  }
-
-  if (hasPluginRepositoriesChanged(current, desired)) {
-    logger.info(
-      `PluginRepositories changed: ${JSON.stringify(fromPluginRepositorySchemas(current.PluginRepositories))} → ${JSON.stringify(desired.pluginRepositories)}`,
-    );
-  }
-
-  if (hasTrickplayOptionsChanged(current, desired)) {
-    logger.info(
-      `TrickplayOptions changed: ${JSON.stringify(current.TrickplayOptions)} → ${JSON.stringify(desired.trickplayOptions)}`,
-    );
-  }
-
-  const out: ServerConfigurationSchema = { ...current };
-
-  if ("EnableMetrics" in patch) {
-    out.EnableMetrics = patch.EnableMetrics;
-  }
-
-  if (typeof patch.PluginRepositories !== "undefined") {
-    out.PluginRepositories = patch.PluginRepositories;
-  }
-
-  if (typeof patch.TrickplayOptions !== "undefined") {
-    const cur: TrickplayOptionsSchema = current.TrickplayOptions ?? {};
-    out.TrickplayOptions = { ...cur, ...patch.TrickplayOptions };
-  }
-
-  return out;
+  return undefined;
 }
 
 export async function applySystem(

--- a/src/lib/changeset.ts
+++ b/src/lib/changeset.ts
@@ -22,6 +22,12 @@ abstract class BaseChangeSetBuilder<T extends IChangeBase> {
     );
   }
 
+  withoutUpdates(): this {
+    return this.create(
+      this.changes.filter((c: IChange) => c.type !== Operation.UPDATE),
+    );
+  }
+
   withKey(key: string): this {
     return this.create(this.changes.filter((c: IChange) => c.key === key));
   }

--- a/src/lib/changeset.ts
+++ b/src/lib/changeset.ts
@@ -1,0 +1,52 @@
+import {
+  Operation,
+  atomizeChangeset,
+  unatomizeChangeset,
+  type IChange,
+  type IAtomicChange,
+} from "json-diff-ts";
+
+interface IChangeBase {
+  type: Operation;
+  key: string;
+}
+
+abstract class BaseChangeSetBuilder<T extends IChangeBase> {
+  constructor(protected changes: T[]) {}
+
+  protected abstract create(changes: T[]): this;
+
+  withoutRemoves(): this {
+    return this.create(
+      this.changes.filter((c: IChange) => c.type !== Operation.REMOVE),
+    );
+  }
+
+  withKey(key: string): this {
+    return this.create(this.changes.filter((c: IChange) => c.key === key));
+  }
+
+  toArray(): T[] {
+    return this.changes;
+  }
+}
+
+export class ChangeSetBuilder extends BaseChangeSetBuilder<IChange> {
+  protected create(changes: IChange[]): this {
+    return new ChangeSetBuilder(changes) as this;
+  }
+
+  atomize(): AtomicChangeSetBuilder {
+    return new AtomicChangeSetBuilder(atomizeChangeset(this.changes));
+  }
+}
+
+export class AtomicChangeSetBuilder extends BaseChangeSetBuilder<IAtomicChange> {
+  protected create(changes: IAtomicChange[]): this {
+    return new AtomicChangeSetBuilder(changes) as this;
+  }
+
+  unatomize(): ChangeSetBuilder {
+    return new ChangeSetBuilder(unatomizeChangeset(this.changes));
+  }
+}

--- a/src/mappers/branding-options.ts
+++ b/src/mappers/branding-options.ts
@@ -5,18 +5,8 @@ export function mapBrandingOptionsConfigToSchema(
   desired: BrandingOptionsConfig,
 ): Partial<BrandingOptionsDtoSchema> {
   const out: Partial<BrandingOptionsDtoSchema> = {};
-
-  if (desired.loginDisclaimer !== undefined) {
-    out.LoginDisclaimer = desired.loginDisclaimer;
-  }
-
-  if (desired.customCss !== undefined) {
-    out.CustomCss = desired.customCss;
-  }
-
-  if (desired.splashscreenEnabled !== undefined) {
-    out.SplashscreenEnabled = desired.splashscreenEnabled;
-  }
-
+  out.LoginDisclaimer = desired.loginDisclaimer;
+  out.CustomCss = desired.customCss;
+  out.SplashscreenEnabled = desired.splashscreenEnabled;
   return out;
 }

--- a/src/mappers/library.ts
+++ b/src/mappers/library.ts
@@ -1,22 +1,29 @@
 import type { VirtualFolderConfig } from "../types/config/library";
 import type {
-  AddVirtualFolderDtoSchema,
   LibraryOptionsSchema,
-  MediaPathInfoSchema,
+  VirtualFolderInfoSchema,
 } from "../types/schema/library";
 
-export function mapVirtualFolderConfigToAddVirtualFolderDto(
-  desired: VirtualFolderConfig,
-): AddVirtualFolderDtoSchema {
-  const libraryOptions: LibraryOptionsSchema = {
-    PathInfos: desired.libraryOptions.pathInfos.map(
-      (pathInfo: { path: string }): MediaPathInfoSchema => ({
-        Path: pathInfo.path,
-      }),
-    ),
-  } as LibraryOptionsSchema;
-
+export function mapVirtualFolderConfigToSchema(
+  config: VirtualFolderConfig,
+): Partial<VirtualFolderInfoSchema> {
   return {
-    LibraryOptions: libraryOptions,
+    Name: config.name,
+    CollectionType: config.collectionType,
+    LibraryOptions: {
+      PathInfos: config.libraryOptions.pathInfos.map(
+        (pathInfo: { path: string }) => ({
+          Path: pathInfo.path,
+        }),
+      ),
+    } as LibraryOptionsSchema,
+  };
+}
+
+export function mapVirtualFolderInfoSchemaToAddVirtualFolderDtoSchema(
+  virtualFolderInfoSchema: VirtualFolderInfoSchema,
+): { LibraryOptions: VirtualFolderInfoSchema["LibraryOptions"] } {
+  return {
+    LibraryOptions: virtualFolderInfoSchema.LibraryOptions,
   };
 }

--- a/src/mappers/system.ts
+++ b/src/mappers/system.ts
@@ -9,19 +9,6 @@ import {
   type PluginRepositorySchema,
 } from "../types/schema/system";
 
-export function fromPluginRepositorySchemas(
-  inRepos: PluginRepositorySchema[] | undefined,
-): PluginRepositoryConfig[] {
-  if (!inRepos) return [];
-  return inRepos.map(
-    (r: PluginRepositorySchema): PluginRepositoryConfig => ({
-      name: r.Name ?? "",
-      url: r.Url ?? "",
-      enabled: Boolean(r.Enabled),
-    }),
-  );
-}
-
 export function toPluginRepositorySchemas(
   inRepos: PluginRepositoryConfig[],
 ): PluginRepositorySchema[] {
@@ -34,34 +21,32 @@ export function toPluginRepositorySchemas(
   );
 }
 
+export function toTrickplayOptionsSchema(
+  cfg: TrickplayOptionsConfig,
+): TrickplayOptionsSchema {
+  const out: TrickplayOptionsSchema = {};
+  out.EnableHwAcceleration = cfg.enableHwAcceleration;
+  out.EnableHwEncoding = cfg.enableHwEncoding;
+  return out;
+}
+
 export function mapSystemConfigurationConfigToSchema(
   desired: SystemConfig,
 ): Partial<ServerConfigurationSchema> {
   const out: Partial<ServerConfigurationSchema> = {};
 
-  if (typeof desired.enableMetrics !== "undefined") {
+  if (desired.enableMetrics !== undefined) {
     out.EnableMetrics = desired.enableMetrics;
   }
 
-  if (typeof desired.pluginRepositories !== "undefined") {
+  if (desired.pluginRepositories !== undefined) {
     out.PluginRepositories = toPluginRepositorySchemas(
       desired.pluginRepositories,
     );
   }
 
-  if (typeof desired.trickplayOptions !== "undefined") {
-    const cfg: TrickplayOptionsConfig = desired.trickplayOptions;
-    const next: TrickplayOptionsSchema = {};
-
-    if ("enableHwAcceleration" in cfg) {
-      next.EnableHwAcceleration = cfg.enableHwAcceleration;
-    }
-
-    if ("enableHwEncoding" in cfg) {
-      next.EnableHwEncoding = cfg.enableHwEncoding;
-    }
-
-    out.TrickplayOptions = next;
+  if (desired.trickplayOptions !== undefined) {
+    out.TrickplayOptions = toTrickplayOptionsSchema(desired.trickplayOptions);
   }
 
   return out;

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -17,7 +17,6 @@ import {
   applyUserPolicies,
 } from "../apply/users";
 import type { VirtualFolderInfoSchema } from "../types/schema/library";
-import type { LibraryConfig } from "../types/config/library";
 import { type ServerConfigurationSchema } from "../types/schema/system";
 import { type EncodingOptionsSchema } from "../types/schema/encoding-options";
 import { type BrandingOptionsDtoSchema } from "../types/schema/branding-options";
@@ -84,15 +83,15 @@ export async function runPipeline(path: string): Promise<void> {
     }
   }
 
-  if (cfg.library) {
+  if (cfg.library?.virtualFolders) {
     const currentVirtualFolders: VirtualFolderInfoSchema[] =
       await jellyfinClient.getVirtualFolders();
-    const updatedLibraryConfig: LibraryConfig | undefined =
-      calculateLibraryDiff(currentVirtualFolders, cfg.library);
+    const foldersToCreate: VirtualFolderInfoSchema[] | undefined =
+      calculateLibraryDiff(currentVirtualFolders, cfg.library.virtualFolders);
 
-    if (updatedLibraryConfig) {
+    if (foldersToCreate) {
       console.log("→ updating library config");
-      await applyLibrary(jellyfinClient, updatedLibraryConfig);
+      await applyLibrary(jellyfinClient, foldersToCreate);
       console.log("✓ updated library config");
     } else {
       console.log("✓ library config already up to date");

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -12,9 +12,9 @@ import {
 } from "../apply/branding-options";
 import {
   calculateNewUsersDiff,
-  applyNewUsers,
   calculateUserPoliciesDiff,
   applyUserPolicies,
+  createNewUsers,
 } from "../apply/users";
 import type { VirtualFolderInfoSchema } from "../types/schema/library";
 import { type ServerConfigurationSchema } from "../types/schema/system";
@@ -124,7 +124,7 @@ export async function runPipeline(path: string): Promise<void> {
 
     if (usersToCreate) {
       console.log("→ creating users");
-      await applyNewUsers(jellyfinClient, usersToCreate);
+      await createNewUsers(jellyfinClient, usersToCreate);
       console.log("✓ created users");
       currentUsers = await jellyfinClient.getUsers();
     }

--- a/src/types/schema/library.ts
+++ b/src/types/schema/library.ts
@@ -2,11 +2,11 @@ import type { components } from "../../../generated/schema";
 
 export type AddVirtualFolderDtoSchema =
   components["schemas"]["AddVirtualFolderDto"];
-export type LibraryOptionsSchema = components["schemas"]["LibraryOptions"];
-export type MediaPathInfoSchema = components["schemas"]["MediaPathInfo"];
 
 export type VirtualFolderInfoSchema =
   components["schemas"]["VirtualFolderInfo"];
 export type CollectionTypeSchema = NonNullable<
   VirtualFolderInfoSchema["CollectionType"]
 >;
+export type LibraryOptionsSchema = components["schemas"]["LibraryOptions"];
+export type MediaPathInfoSchema = components["schemas"]["MediaPathInfo"];

--- a/tests/apply/branding-options.spec.ts
+++ b/tests/apply/branding-options.spec.ts
@@ -145,7 +145,7 @@ describe("calculateBrandingOptionsDiff", () => {
     expect(result?.SplashscreenEnabled).toBe(true);
   });
 
-  it("should not detect change when setting empty string to null", () => {
+  it("should detect change when setting empty string to null", () => {
     const current: BrandingOptionsDtoSchema = {
       LoginDisclaimer: null,
       CustomCss: null,
@@ -159,7 +159,9 @@ describe("calculateBrandingOptionsDiff", () => {
     const result: BrandingOptionsDtoSchema | undefined =
       calculateBrandingOptionsDiff(current, desired);
 
-    expect(result).toBeUndefined();
+    expect(result).toBeDefined();
+    expect(result?.LoginDisclaimer).toBe("");
+    expect(result?.CustomCss).toBe("");
   });
 
   it("should handle multiple changes", () => {

--- a/tests/apply/encoding-options.spec.ts
+++ b/tests/apply/encoding-options.spec.ts
@@ -59,7 +59,6 @@ import {
 import type { JellyfinClient } from "../../src/api/jellyfin.types";
 import { type EncodingOptionsConfig } from "../../src/types/config/encoding-options";
 import { type EncodingOptionsSchema } from "../../src/types/schema/encoding-options";
-import * as loggerModule from "../../src/lib/logger";
 
 vi.mock("../../src/lib/logger", () => ({
   logger: {
@@ -159,72 +158,6 @@ describe("apply/encoding", () => {
 
       // Assert
       expect(result).toBeUndefined();
-    });
-
-    it("should log when EnableHardwareEncoding changes", () => {
-      // Arrange
-      const current: EncodingOptionsSchema = {
-        EnableHardwareEncoding: false,
-      } as EncodingOptionsSchema;
-
-      const desired: EncodingOptionsConfig = {
-        enableHardwareEncoding: true,
-      };
-
-      const loggerSpy: Mock<(msg: string) => void> = vi.spyOn(
-        loggerModule.logger,
-        "info",
-      );
-
-      // Act
-      calculateEncodingDiff(current, desired);
-
-      // Assert
-      expect(loggerSpy).toHaveBeenCalledWith(
-        "EnableHardwareEncoding changed: false → true",
-      );
-    });
-
-    it("should not log when EnableHardwareEncoding does not change", () => {
-      // Arrange
-      const current: EncodingOptionsSchema = {
-        EnableHardwareEncoding: true,
-      } as EncodingOptionsSchema;
-
-      const desired: EncodingOptionsConfig = {
-        enableHardwareEncoding: true,
-      };
-
-      const loggerSpy: Mock<(msg: string) => void> = vi.spyOn(
-        loggerModule.logger,
-        "info",
-      );
-
-      // Act
-      calculateEncodingDiff(current, desired);
-
-      // Assert
-      expect(loggerSpy).not.toHaveBeenCalled();
-    });
-
-    it("should not log when enableHardwareEncoding is undefined", () => {
-      // Arrange
-      const current: EncodingOptionsSchema = {
-        EnableHardwareEncoding: true,
-      } as EncodingOptionsSchema;
-
-      const desired: EncodingOptionsConfig = {};
-
-      const loggerSpy: Mock<(msg: string) => void> = vi.spyOn(
-        loggerModule.logger,
-        "info",
-      );
-
-      // Act
-      calculateEncodingDiff(current, desired);
-
-      // Assert
-      expect(loggerSpy).not.toHaveBeenCalled();
     });
 
     it("should update HardwareAccelerationType when hardwareAccelerationType changes", () => {
@@ -339,96 +272,6 @@ describe("apply/encoding", () => {
       });
     });
 
-    it("should log when HardwareAccelerationType changes", () => {
-      // Arrange
-      const current: EncodingOptionsSchema = {
-        HardwareAccelerationType: "none",
-      } as EncodingOptionsSchema;
-
-      const desired: EncodingOptionsConfig = {
-        hardwareAccelerationType: "nvenc",
-      };
-
-      const loggerSpy: Mock<(msg: string) => void> = vi.spyOn(
-        loggerModule.logger,
-        "info",
-      );
-
-      // Act
-      calculateEncodingDiff(current, desired);
-
-      // Assert
-      expect(loggerSpy).toHaveBeenCalledWith(
-        "HardwareAccelerationType changed: none → nvenc",
-      );
-    });
-
-    it("should log when HardwareAccelerationType changes from undefined (defaults to none)", () => {
-      // Arrange
-      const current: EncodingOptionsSchema = {
-        HardwareAccelerationType: undefined,
-      } as EncodingOptionsSchema;
-
-      const desired: EncodingOptionsConfig = {
-        hardwareAccelerationType: "vaapi",
-      };
-
-      const loggerSpy: Mock<(msg: string) => void> = vi.spyOn(
-        loggerModule.logger,
-        "info",
-      );
-
-      // Act
-      calculateEncodingDiff(current, desired);
-
-      // Assert
-      expect(loggerSpy).toHaveBeenCalledWith(
-        "HardwareAccelerationType changed: none → vaapi",
-      );
-    });
-
-    it("should not log when HardwareAccelerationType does not change", () => {
-      // Arrange
-      const current: EncodingOptionsSchema = {
-        HardwareAccelerationType: "qsv",
-      } as EncodingOptionsSchema;
-
-      const desired: EncodingOptionsConfig = {
-        hardwareAccelerationType: "qsv",
-      };
-
-      const loggerSpy: Mock<(msg: string) => void> = vi.spyOn(
-        loggerModule.logger,
-        "info",
-      );
-
-      // Act
-      calculateEncodingDiff(current, desired);
-
-      // Assert
-      expect(loggerSpy).not.toHaveBeenCalled();
-    });
-
-    it("should not log when hardwareAccelerationType is undefined", () => {
-      // Arrange
-      const current: EncodingOptionsSchema = {
-        HardwareAccelerationType: "amf",
-      } as EncodingOptionsSchema;
-
-      const desired: EncodingOptionsConfig = {};
-
-      const loggerSpy: Mock<(msg: string) => void> = vi.spyOn(
-        loggerModule.logger,
-        "info",
-      );
-
-      // Act
-      calculateEncodingDiff(current, desired);
-
-      // Assert
-      expect(loggerSpy).not.toHaveBeenCalled();
-    });
-
     it("should handle both enableHardwareEncoding and hardwareAccelerationType changes together", () => {
       // Arrange
       const current: EncodingOptionsSchema = {
@@ -442,11 +285,6 @@ describe("apply/encoding", () => {
         hardwareAccelerationType: "nvenc",
       };
 
-      const loggerSpy: Mock<(msg: string) => void> = vi.spyOn(
-        loggerModule.logger,
-        "info",
-      );
-
       // Act
       const result: EncodingOptionsSchema | undefined = calculateEncodingDiff(
         current,
@@ -457,14 +295,6 @@ describe("apply/encoding", () => {
       expect(result?.EnableHardwareEncoding).toBe(true);
       expect(result?.HardwareAccelerationType).toBe("nvenc");
       expect(result?.EncodingThreadCount).toBe(4);
-
-      expect(loggerSpy).toHaveBeenCalledWith(
-        "EnableHardwareEncoding changed: false → true",
-      );
-      expect(loggerSpy).toHaveBeenCalledWith(
-        "HardwareAccelerationType changed: none → nvenc",
-      );
-      expect(loggerSpy).toHaveBeenCalledTimes(2);
     });
 
     it("should handle mixed scenarios where one field changes and one stays same", () => {
@@ -479,11 +309,6 @@ describe("apply/encoding", () => {
         hardwareAccelerationType: "videotoolbox",
       };
 
-      const loggerSpy: Mock<(msg: string) => void> = vi.spyOn(
-        loggerModule.logger,
-        "info",
-      );
-
       // Act
       const result: EncodingOptionsSchema | undefined = calculateEncodingDiff(
         current,
@@ -493,11 +318,6 @@ describe("apply/encoding", () => {
       // Assert
       expect(result?.EnableHardwareEncoding).toBe(true);
       expect(result?.HardwareAccelerationType).toBe("videotoolbox");
-
-      expect(loggerSpy).toHaveBeenCalledWith(
-        "HardwareAccelerationType changed: vaapi → videotoolbox",
-      );
-      expect(loggerSpy).toHaveBeenCalledTimes(1);
     });
 
     describe("device fields", () => {
@@ -663,54 +483,6 @@ describe("apply/encoding", () => {
         // Assert
         expect(result).toBeUndefined();
       });
-
-      it("should log when VaapiDevice changes", () => {
-        // Arrange
-        const current: EncodingOptionsSchema = {
-          VaapiDevice: "",
-        } as EncodingOptionsSchema;
-
-        const desired: EncodingOptionsConfig = {
-          vaapiDevice: "/dev/dri/renderD128",
-        };
-
-        const loggerSpy: Mock<(msg: string) => void> = vi.spyOn(
-          loggerModule.logger,
-          "info",
-        );
-
-        // Act
-        calculateEncodingDiff(current, desired);
-
-        // Assert
-        expect(loggerSpy).toHaveBeenCalledWith(
-          'VaapiDevice changed: "" → "/dev/dri/renderD128"',
-        );
-      });
-
-      it("should log when QsvDevice changes", () => {
-        // Arrange
-        const current: EncodingOptionsSchema = {
-          QsvDevice: "/old/path",
-        } as EncodingOptionsSchema;
-
-        const desired: EncodingOptionsConfig = {
-          qsvDevice: "/new/path",
-        };
-
-        const loggerSpy: Mock<(msg: string) => void> = vi.spyOn(
-          loggerModule.logger,
-          "info",
-        );
-
-        // Act
-        calculateEncodingDiff(current, desired);
-
-        // Assert
-        expect(loggerSpy).toHaveBeenCalledWith(
-          'QsvDevice changed: "/old/path" → "/new/path"',
-        );
-      });
     });
 
     describe("hardwareDecodingCodecs array field", () => {
@@ -829,30 +601,6 @@ describe("apply/encoding", () => {
         // Assert
         expect(result).toBeUndefined();
       });
-
-      it("should log when HardwareDecodingCodecs changes", () => {
-        // Arrange
-        const current: EncodingOptionsSchema = {
-          HardwareDecodingCodecs: ["h264"],
-        } as EncodingOptionsSchema;
-
-        const desired: EncodingOptionsConfig = {
-          hardwareDecodingCodecs: ["h264", "hevc", "vp9"],
-        };
-
-        const loggerSpy: Mock<(msg: string) => void> = vi.spyOn(
-          loggerModule.logger,
-          "info",
-        );
-
-        // Act
-        calculateEncodingDiff(current, desired);
-
-        // Assert
-        expect(loggerSpy).toHaveBeenCalledWith(
-          "HardwareDecodingCodecs changed: [h264] → [h264, hevc, vp9]",
-        );
-      });
     });
 
     describe("boolean decoding fields", () => {
@@ -912,30 +660,6 @@ describe("apply/encoding", () => {
           // Assert
           expect(result).toBeUndefined();
         });
-
-        it("should log when EnableDecodingColorDepth10Hevc changes", () => {
-          // Arrange
-          const current: EncodingOptionsSchema = {
-            EnableDecodingColorDepth10Hevc: false,
-          } as EncodingOptionsSchema;
-
-          const desired: EncodingOptionsConfig = {
-            enableDecodingColorDepth10Hevc: true,
-          };
-
-          const loggerSpy: Mock<(msg: string) => void> = vi.spyOn(
-            loggerModule.logger,
-            "info",
-          );
-
-          // Act
-          calculateEncodingDiff(current, desired);
-
-          // Assert
-          expect(loggerSpy).toHaveBeenCalledWith(
-            "EnableDecodingColorDepth10Hevc changed: false → true",
-          );
-        });
       });
 
       describe("enableDecodingColorDepth10Vp9", () => {
@@ -975,30 +699,6 @@ describe("apply/encoding", () => {
               expect(result?.EnableDecodingColorDepth10Vp9).toBe(desiredValue);
               expect(result?.EncodingThreadCount).toBe(3);
             },
-          );
-        });
-
-        it("should log when EnableDecodingColorDepth10Vp9 changes", () => {
-          // Arrange
-          const current: EncodingOptionsSchema = {
-            EnableDecodingColorDepth10Vp9: true,
-          } as EncodingOptionsSchema;
-
-          const desired: EncodingOptionsConfig = {
-            enableDecodingColorDepth10Vp9: false,
-          };
-
-          const loggerSpy: Mock<(msg: string) => void> = vi.spyOn(
-            loggerModule.logger,
-            "info",
-          );
-
-          // Act
-          calculateEncodingDiff(current, desired);
-
-          // Assert
-          expect(loggerSpy).toHaveBeenCalledWith(
-            "EnableDecodingColorDepth10Vp9 changed: true → false",
           );
         });
       });
@@ -1044,30 +744,6 @@ describe("apply/encoding", () => {
             },
           );
         });
-
-        it("should log when EnableDecodingColorDepth10HevcRext changes", () => {
-          // Arrange
-          const current: EncodingOptionsSchema = {
-            EnableDecodingColorDepth10HevcRext: false,
-          } as EncodingOptionsSchema;
-
-          const desired: EncodingOptionsConfig = {
-            enableDecodingColorDepth10HevcRext: true,
-          };
-
-          const loggerSpy: Mock<(msg: string) => void> = vi.spyOn(
-            loggerModule.logger,
-            "info",
-          );
-
-          // Act
-          calculateEncodingDiff(current, desired);
-
-          // Assert
-          expect(loggerSpy).toHaveBeenCalledWith(
-            "EnableDecodingColorDepth10HevcRext changed: false → true",
-          );
-        });
       });
 
       describe("enableDecodingColorDepth12HevcRext", () => {
@@ -1109,30 +785,6 @@ describe("apply/encoding", () => {
               );
               expect(result?.EncodingThreadCount).toBe(5);
             },
-          );
-        });
-
-        it("should log when EnableDecodingColorDepth12HevcRext changes", () => {
-          // Arrange
-          const current: EncodingOptionsSchema = {
-            EnableDecodingColorDepth12HevcRext: true,
-          } as EncodingOptionsSchema;
-
-          const desired: EncodingOptionsConfig = {
-            enableDecodingColorDepth12HevcRext: false,
-          };
-
-          const loggerSpy: Mock<(msg: string) => void> = vi.spyOn(
-            loggerModule.logger,
-            "info",
-          );
-
-          // Act
-          calculateEncodingDiff(current, desired);
-
-          // Assert
-          expect(loggerSpy).toHaveBeenCalledWith(
-            "EnableDecodingColorDepth12HevcRext changed: true → false",
           );
         });
       });
@@ -1195,30 +847,6 @@ describe("apply/encoding", () => {
           // Assert
           expect(result).toBeUndefined();
         });
-
-        it("should log when AllowHevcEncoding changes", () => {
-          // Arrange
-          const current: EncodingOptionsSchema = {
-            AllowHevcEncoding: false,
-          } as EncodingOptionsSchema;
-
-          const desired: EncodingOptionsConfig = {
-            allowHevcEncoding: true,
-          };
-
-          const loggerSpy: Mock<(msg: string) => void> = vi.spyOn(
-            loggerModule.logger,
-            "info",
-          );
-
-          // Act
-          calculateEncodingDiff(current, desired);
-
-          // Assert
-          expect(loggerSpy).toHaveBeenCalledWith(
-            "AllowHevcEncoding changed: false → true",
-          );
-        });
       });
 
       describe("allowAv1Encoding", () => {
@@ -1277,30 +905,6 @@ describe("apply/encoding", () => {
           // Assert
           expect(result).toBeUndefined();
         });
-
-        it("should log when AllowAv1Encoding changes", () => {
-          // Arrange
-          const current: EncodingOptionsSchema = {
-            AllowAv1Encoding: true,
-          } as EncodingOptionsSchema;
-
-          const desired: EncodingOptionsConfig = {
-            allowAv1Encoding: false,
-          };
-
-          const loggerSpy: Mock<(msg: string) => void> = vi.spyOn(
-            loggerModule.logger,
-            "info",
-          );
-
-          // Act
-          calculateEncodingDiff(current, desired);
-
-          // Assert
-          expect(loggerSpy).toHaveBeenCalledWith(
-            "AllowAv1Encoding changed: true → false",
-          );
-        });
       });
     });
 
@@ -1335,11 +939,6 @@ describe("apply/encoding", () => {
         allowAv1Encoding: false,
       };
 
-      const loggerSpy: Mock<(msg: string) => void> = vi.spyOn(
-        loggerModule.logger,
-        "info",
-      );
-
       // Act
       const result: EncodingOptionsSchema | undefined = calculateEncodingDiff(
         current,
@@ -1364,43 +963,6 @@ describe("apply/encoding", () => {
       expect(result?.AllowHevcEncoding).toBe(false);
       expect(result?.AllowAv1Encoding).toBe(false);
       expect(result?.EncodingThreadCount).toBe(8);
-
-      expect(loggerSpy).toHaveBeenCalledWith(
-        "EnableHardwareEncoding changed: false → true",
-      );
-      expect(loggerSpy).toHaveBeenCalledWith(
-        "HardwareAccelerationType changed: none → vaapi",
-      );
-      expect(loggerSpy).toHaveBeenCalledWith(
-        'VaapiDevice changed: "" → "/dev/dri/renderD128"',
-      );
-      expect(loggerSpy).toHaveBeenCalledWith(
-        "HardwareDecodingCodecs changed: [] → [h264, hevc, vp9, av1]",
-      );
-      expect(loggerSpy).toHaveBeenCalledWith(
-        "EnableDecodingColorDepth10Hevc changed: false → true",
-      );
-      expect(loggerSpy).toHaveBeenCalledWith(
-        "EnableDecodingColorDepth10HevcRext changed: false → true",
-      );
-
-      expect(loggerSpy).not.toHaveBeenCalledWith(
-        expect.stringContaining("QsvDevice changed"),
-      );
-      expect(loggerSpy).not.toHaveBeenCalledWith(
-        expect.stringContaining("EnableDecodingColorDepth10Vp9 changed"),
-      );
-      expect(loggerSpy).not.toHaveBeenCalledWith(
-        expect.stringContaining("EnableDecodingColorDepth12HevcRext changed"),
-      );
-      expect(loggerSpy).not.toHaveBeenCalledWith(
-        expect.stringContaining("AllowHevcEncoding changed"),
-      );
-      expect(loggerSpy).not.toHaveBeenCalledWith(
-        expect.stringContaining("AllowAv1Encoding changed"),
-      );
-
-      expect(loggerSpy).toHaveBeenCalledTimes(6);
     });
   });
 

--- a/tests/apply/system.spec.ts
+++ b/tests/apply/system.spec.ts
@@ -36,7 +36,6 @@ import { calculateSystemDiff, applySystem } from "../../src/apply/system";
 import type { JellyfinClient } from "../../src/api/jellyfin.types";
 import type { ServerConfigurationSchema } from "../../src/types/schema/system";
 import type { SystemConfig } from "../../src/types/config/system";
-import * as loggerModule from "../../src/lib/logger";
 
 vi.mock("../../src/lib/logger", () => ({
   logger: {
@@ -163,74 +162,6 @@ describe("apply/system", () => {
 
         // Assert
         expect(result).toBeUndefined();
-      });
-
-      it("should log when EnableMetrics changes", () => {
-        // Arrange
-        const current: ServerConfigurationSchema = {
-          EnableMetrics: false,
-          PluginRepositories: [],
-          TrickplayOptions: undefined,
-        } as ServerConfigurationSchema;
-
-        const desired: SystemConfig = { enableMetrics: true };
-
-        const loggerSpy: Mock<(msg: string) => void> = vi.spyOn(
-          loggerModule.logger,
-          "info",
-        );
-
-        // Act
-        calculateSystemDiff(current, desired);
-
-        // Assert
-        expect(loggerSpy).toHaveBeenCalledWith(
-          "EnableMetrics changed: false → true",
-        );
-      });
-
-      it("should not log when EnableMetrics does not change", () => {
-        // Arrange
-        const current: ServerConfigurationSchema = {
-          EnableMetrics: true,
-          PluginRepositories: [],
-          TrickplayOptions: undefined,
-        } as ServerConfigurationSchema;
-
-        const desired: SystemConfig = { enableMetrics: true };
-
-        const loggerSpy: Mock<(msg: string) => void> = vi.spyOn(
-          loggerModule.logger,
-          "info",
-        );
-
-        // Act
-        calculateSystemDiff(current, desired);
-
-        // Assert
-        expect(loggerSpy).not.toHaveBeenCalled();
-      });
-
-      it("should not log when enableMetrics is undefined", () => {
-        // Arrange
-        const current: ServerConfigurationSchema = {
-          EnableMetrics: true,
-          PluginRepositories: [],
-          TrickplayOptions: undefined,
-        } as ServerConfigurationSchema;
-
-        const desired: SystemConfig = {};
-
-        const loggerSpy: Mock<(msg: string) => void> = vi.spyOn(
-          loggerModule.logger,
-          "info",
-        );
-
-        // Act
-        calculateSystemDiff(current, desired);
-
-        // Assert
-        expect(loggerSpy).not.toHaveBeenCalled();
       });
     });
 
@@ -470,63 +401,6 @@ describe("apply/system", () => {
         // Assert
         expect(result).toBeUndefined();
       });
-
-      it("should log when PluginRepositories changes", () => {
-        // Arrange
-        const current: ServerConfigurationSchema = {
-          EnableMetrics: false,
-          PluginRepositories: [
-            { Name: "Old", Url: "https://old.com", Enabled: true },
-          ],
-          TrickplayOptions: undefined,
-        } as ServerConfigurationSchema;
-
-        const desired: SystemConfig = {
-          pluginRepositories: [
-            { name: "New", url: "https://new.com", enabled: false },
-          ],
-        };
-
-        const loggerSpy: Mock<(msg: string) => void> = vi.spyOn(
-          loggerModule.logger,
-          "info",
-        );
-
-        // Act
-        calculateSystemDiff(current, desired);
-
-        // Assert
-        expect(loggerSpy).toHaveBeenCalledWith(
-          'PluginRepositories changed: [{"name":"Old","url":"https://old.com","enabled":true}] → [{"name":"New","url":"https://new.com","enabled":false}]',
-        );
-      });
-
-      it("should not log when PluginRepositories does not change", () => {
-        // Arrange
-        const existingRepos: Array<{
-          Name: string;
-          Url: string;
-          Enabled: boolean;
-        }> = [{ Name: "Same", Url: "https://same.com", Enabled: true }];
-        const current: ServerConfigurationSchema = {
-          EnableMetrics: false,
-          PluginRepositories: existingRepos,
-          TrickplayOptions: undefined,
-        } as ServerConfigurationSchema;
-
-        const desired: SystemConfig = {};
-
-        const loggerSpy: Mock<(msg: string) => void> = vi.spyOn(
-          loggerModule.logger,
-          "info",
-        );
-
-        // Act
-        calculateSystemDiff(current, desired);
-
-        // Assert
-        expect(loggerSpy).not.toHaveBeenCalled();
-      });
     });
 
     describe("trickplayOptions (Object)", () => {
@@ -756,60 +630,6 @@ describe("apply/system", () => {
         expect(result?.TrickplayOptions?.EnableHwEncoding).toBe(true);
         expect(result?.EnableMetrics).toBe(false);
         expect(result?.PluginRepositories).toEqual([]);
-      });
-
-      it("should log when TrickplayOptions changes", () => {
-        // Arrange
-        const current: ServerConfigurationSchema = {
-          EnableMetrics: false,
-          PluginRepositories: [],
-          TrickplayOptions: {
-            EnableHwAcceleration: false,
-            EnableHwEncoding: true,
-          },
-        } as ServerConfigurationSchema;
-
-        const desired: SystemConfig = {
-          trickplayOptions: { enableHwAcceleration: true },
-        };
-
-        const loggerSpy: Mock<(msg: string) => void> = vi.spyOn(
-          loggerModule.logger,
-          "info",
-        );
-
-        // Act
-        calculateSystemDiff(current, desired);
-
-        // Assert
-        expect(loggerSpy).toHaveBeenCalledWith(
-          'TrickplayOptions changed: {"EnableHwAcceleration":false,"EnableHwEncoding":true} → {"enableHwAcceleration":true}',
-        );
-      });
-
-      it("should not log when TrickplayOptions does not change", () => {
-        // Arrange
-        const current: ServerConfigurationSchema = {
-          EnableMetrics: false,
-          PluginRepositories: [],
-          TrickplayOptions: {
-            EnableHwAcceleration: true,
-            EnableHwEncoding: false,
-          },
-        } as ServerConfigurationSchema;
-
-        const desired: SystemConfig = {};
-
-        const loggerSpy: Mock<(msg: string) => void> = vi.spyOn(
-          loggerModule.logger,
-          "info",
-        );
-
-        // Act
-        calculateSystemDiff(current, desired);
-
-        // Assert
-        expect(loggerSpy).not.toHaveBeenCalled();
       });
     });
 

--- a/tests/apply/users.spec.ts
+++ b/tests/apply/users.spec.ts
@@ -11,8 +11,6 @@ import type {
   UserDtoSchema,
   UserPolicySchema,
 } from "../../src/types/schema/users";
-import { logger } from "../../src/lib/logger";
-
 vi.mock("../../src/lib/logger", () => ({
   logger: {
     info: vi.fn(),
@@ -615,47 +613,6 @@ describe("calculateUserPoliciesDiff", () => {
 
     // Assert
     expect(result).toBeUndefined();
-  });
-
-  it("should log when user policy updates are detected", () => {
-    // Arrange
-    const config: UserConfigList = [
-      {
-        name: "existing-user",
-        password: "password",
-        policy: {
-          isAdministrator: true,
-        },
-      },
-    ];
-
-    const loggerSpy: Mock<(msg: string) => void> = vi.spyOn(logger, "info");
-
-    // Act
-    calculateUserPoliciesDiff(currentUsers, config);
-
-    // Assert
-    expect(loggerSpy).toHaveBeenCalledWith(
-      "Updating user policy: existing-user",
-    );
-  });
-
-  it("should not log when no user policy changes detected", () => {
-    // Arrange
-    const config: UserConfigList = [
-      {
-        name: "existing-user",
-        password: "password",
-      },
-    ];
-
-    const loggerSpy: Mock<(msg: string) => void> = vi.spyOn(logger, "info");
-
-    // Act
-    calculateUserPoliciesDiff(currentUsers, config);
-
-    // Assert
-    expect(loggerSpy).not.toHaveBeenCalled();
   });
 
   it("should not modify policy when isAdministrator is undefined", () => {

--- a/tests/apply/users.spec.ts
+++ b/tests/apply/users.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 import {
   calculateNewUsersDiff,
-  applyNewUsers,
+  createNewUsers,
   calculateUserPoliciesDiff,
   applyUserPolicies,
 } from "../../src/apply/users";
@@ -269,7 +269,7 @@ describe("calculateNewUsersDiff", () => {
   });
 });
 
-describe("applyNewUsers", () => {
+describe("createNewUsers", () => {
   const mockClient: JellyfinClient = {
     createUser: vi.fn(),
   } as unknown as JellyfinClient;
@@ -283,7 +283,7 @@ describe("applyNewUsers", () => {
     const createUserSpy: Mock = vi.spyOn(mockClient, "createUser");
 
     // Act
-    await applyNewUsers(mockClient, undefined);
+    await createNewUsers(mockClient, undefined);
 
     // Assert
     expect(createUserSpy).not.toHaveBeenCalled();
@@ -300,7 +300,7 @@ describe("applyNewUsers", () => {
     ];
 
     // Act
-    await applyNewUsers(mockClient, usersToCreate);
+    await createNewUsers(mockClient, usersToCreate);
 
     // Assert
     expect(createUserSpy).toHaveBeenCalledTimes(1);
@@ -325,7 +325,7 @@ describe("applyNewUsers", () => {
     ];
 
     // Act
-    await applyNewUsers(mockClient, usersToCreate);
+    await createNewUsers(mockClient, usersToCreate);
 
     // Assert
     expect(createUserSpy).toHaveBeenCalledTimes(2);
@@ -345,7 +345,7 @@ describe("applyNewUsers", () => {
     const usersToCreate: UserConfig[] = [];
 
     // Act
-    await applyNewUsers(mockClient, usersToCreate);
+    await createNewUsers(mockClient, usersToCreate);
 
     // Assert
     expect(createUserSpy).not.toHaveBeenCalled();
@@ -353,30 +353,31 @@ describe("applyNewUsers", () => {
 });
 
 describe("calculateUserPoliciesDiff", () => {
+  let currentUsers: UserDtoSchema[];
+
   beforeEach(() => {
     vi.clearAllMocks();
+    currentUsers = [
+      {
+        Name: "existing-user",
+        Id: "user-1-id",
+        ServerId: "server-id",
+        Policy: {
+          IsAdministrator: false,
+          LoginAttemptsBeforeLockout: 5,
+        },
+      } as UserDtoSchema,
+      {
+        Name: "admin-user",
+        Id: "user-2-id",
+        ServerId: "server-id",
+        Policy: {
+          IsAdministrator: true,
+          LoginAttemptsBeforeLockout: 3,
+        },
+      } as UserDtoSchema,
+    ];
   });
-
-  const currentUsers: UserDtoSchema[] = [
-    {
-      Name: "existing-user",
-      Id: "user-1-id",
-      ServerId: "server-id",
-      Policy: {
-        IsAdministrator: false,
-        LoginAttemptsBeforeLockout: 5,
-      },
-    } as UserDtoSchema,
-    {
-      Name: "admin-user",
-      Id: "user-2-id",
-      ServerId: "server-id",
-      Policy: {
-        IsAdministrator: true,
-        LoginAttemptsBeforeLockout: 3,
-      },
-    } as UserDtoSchema,
-  ];
 
   it("should return undefined when no users desired", () => {
     // Arrange

--- a/tests/mappers/library.spec.ts
+++ b/tests/mappers/library.spec.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { mapVirtualFolderConfigToAddVirtualFolderDto } from "../../src/mappers/library";
+import { mapVirtualFolderConfigToSchema } from "../../src/mappers/library";
 import type { VirtualFolderConfig } from "../../src/types/config/library";
-import type { AddVirtualFolderDtoSchema } from "../../src/types/schema/library";
+import type { VirtualFolderInfoSchema } from "../../src/types/schema/library";
 
 describe("mappers/library", () => {
-  describe("mapVirtualFolderConfigToAddVirtualFolderDto", () => {
+  describe("mapVirtualFolderConfigToSchema", () => {
     it("should map single location correctly", () => {
       // Arrange
       const config: VirtualFolderConfig = {
@@ -16,11 +16,13 @@ describe("mappers/library", () => {
       };
 
       // Act
-      const result: AddVirtualFolderDtoSchema =
-        mapVirtualFolderConfigToAddVirtualFolderDto(config);
+      const result: Partial<VirtualFolderInfoSchema> =
+        mapVirtualFolderConfigToSchema(config);
 
       // Assert
       expect(result).toEqual({
+        Name: "Movies",
+        CollectionType: "movies",
         LibraryOptions: {
           PathInfos: [{ Path: "/data/movies" }],
         },
@@ -42,10 +44,12 @@ describe("mappers/library", () => {
       };
 
       // Act
-      const result: AddVirtualFolderDtoSchema =
-        mapVirtualFolderConfigToAddVirtualFolderDto(config);
+      const result: Partial<VirtualFolderInfoSchema> =
+        mapVirtualFolderConfigToSchema(config);
 
       // Assert
+      expect(result.Name).toBe("TV Shows");
+      expect(result.CollectionType).toBe("tvshows");
       expect(result.LibraryOptions?.PathInfos).toHaveLength(3);
       expect(result.LibraryOptions?.PathInfos?.[0]).toEqual({
         Path: "/data/path1",
@@ -90,10 +94,12 @@ describe("mappers/library", () => {
         };
 
         // Act
-        const result: AddVirtualFolderDtoSchema =
-          mapVirtualFolderConfigToAddVirtualFolderDto(config);
+        const result: Partial<VirtualFolderInfoSchema> =
+          mapVirtualFolderConfigToSchema(config);
 
         // Assert
+        expect(result.Name).toBe(`Test ${collectionType}`);
+        expect(result.CollectionType).toBe(collectionType);
         expect(result.LibraryOptions?.PathInfos?.[0]).toEqual({
           Path: `/data/${collectionType}`,
         });
@@ -119,10 +125,12 @@ describe("mappers/library", () => {
       };
 
       // Act
-      const result: AddVirtualFolderDtoSchema =
-        mapVirtualFolderConfigToAddVirtualFolderDto(config);
+      const result: Partial<VirtualFolderInfoSchema> =
+        mapVirtualFolderConfigToSchema(config);
 
       // Assert
+      expect(result.Name).toBe("Complex Paths");
+      expect(result.CollectionType).toBe("movies");
       expect(result.LibraryOptions?.PathInfos).toHaveLength(locations.length);
       locations.forEach((location: string, index: number) => {
         expect(result.LibraryOptions?.PathInfos?.[index]).toEqual({
@@ -131,7 +139,7 @@ describe("mappers/library", () => {
       });
     });
 
-    it("should create proper LibraryOptions structure", () => {
+    it("should create proper schema structure", () => {
       // Arrange
       const config: VirtualFolderConfig = {
         name: "Test",
@@ -142,10 +150,12 @@ describe("mappers/library", () => {
       };
 
       // Act
-      const result: AddVirtualFolderDtoSchema =
-        mapVirtualFolderConfigToAddVirtualFolderDto(config);
+      const result: Partial<VirtualFolderInfoSchema> =
+        mapVirtualFolderConfigToSchema(config);
 
       // Assert
+      expect(result).toHaveProperty("Name");
+      expect(result).toHaveProperty("CollectionType");
       expect(result).toHaveProperty("LibraryOptions");
       expect(result.LibraryOptions).toHaveProperty("PathInfos");
       expect(Array.isArray(result.LibraryOptions?.PathInfos)).toBe(true);

--- a/tests/mappers/system.spec.ts
+++ b/tests/mappers/system.spec.ts
@@ -23,7 +23,6 @@
  */
 import { describe, it, expect } from "vitest";
 import {
-  fromPluginRepositorySchemas,
   toPluginRepositorySchemas,
   mapSystemConfigurationConfigToSchema,
 } from "../../src/mappers/system";
@@ -35,70 +34,6 @@ import type {
 } from "../../src/types/schema/system";
 
 describe("mappers/system", () => {
-  describe("fromPluginRepositorySchemas", () => {
-    it("should convert empty server schema array to empty config array", () => {
-      // Arrange
-      const jfRepos: PluginRepositorySchema[] = [];
-
-      // Act
-      const result: PluginRepositoryConfig[] =
-        fromPluginRepositorySchemas(jfRepos);
-
-      // Assert
-      expect(result).toEqual([]);
-    });
-
-    it("should convert server schema to config format with proper field mapping", () => {
-      // Arrange
-      const jfRepos: PluginRepositorySchema[] = [
-        { Name: "Repository A", Url: "https://repo-a.com", Enabled: true },
-        { Name: "Repository B", Url: "https://repo-b.com", Enabled: false },
-      ];
-
-      // Act
-      const result: PluginRepositoryConfig[] =
-        fromPluginRepositorySchemas(jfRepos);
-
-      // Assert
-      expect(result).toEqual([
-        { name: "Repository A", url: "https://repo-a.com", enabled: true },
-        { name: "Repository B", url: "https://repo-b.com", enabled: false },
-      ]);
-    });
-
-    it("should handle single repository conversion", () => {
-      // Arrange
-      const jfRepos: PluginRepositorySchema[] = [
-        { Name: "Single Repo", Url: "https://single.com", Enabled: true },
-      ];
-
-      // Act
-      const result: PluginRepositoryConfig[] =
-        fromPluginRepositorySchemas(jfRepos);
-
-      // Assert
-      expect(result).toEqual([
-        { name: "Single Repo", url: "https://single.com", enabled: true },
-      ]);
-    });
-
-    it("should convert disabled repositories correctly", () => {
-      // Arrange
-      const jfRepos: PluginRepositorySchema[] = [
-        { Name: "Disabled Repo", Url: "https://disabled.com", Enabled: false },
-      ];
-
-      // Act
-      const result: PluginRepositoryConfig[] =
-        fromPluginRepositorySchemas(jfRepos);
-
-      // Assert
-      expect(result).toEqual([
-        { name: "Disabled Repo", url: "https://disabled.com", enabled: false },
-      ]);
-    });
-  });
-
   describe("toPluginRepositorySchemas", () => {
     it("should convert empty config array to empty server schema array", () => {
       // Arrange


### PR DESCRIPTION
## Summary

Refactors all apply modules to use a unified `json-diff-ts` + `ChangeSetBuilder` pattern for detecting and applying configuration changes.

- Adds `ChangeSetBuilder` fluent API in `src/lib/changeset.ts`
- Refactors branding-options, system, encoding-options, library, and users apply modules
- Simplifies mappers to return partial schema patches
- Removes ~1000 lines of repetitive comparison code
- Fixes test fixture isolation issue in users tests

### Pattern used across all modules:

```typescript
const patch = new ChangeSetBuilder(diff(current, desired))
  .atomize()
  .withoutRemoves()
  .toArray();

if (patch.length > 0) {
  return applyChangeset(current, patch);
}
```

## Test plan

- [x] All 337 tests pass
- [x] `pnpm build && tsc --noEmit && pnpm eslint && pnpm test`
- [x] `nix build .#` succeeds
