### PR TITLE
Plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,55 @@ startup:
 Useful for automated deployments where you want to skip the interactive startup
 wizard.
 
+### Plugin Management
+
+```yaml
+version: 1
+base_url: "http://localhost:8096"
+plugins:
+  # Install plugin by name (from configured repositories)
+  - name: "Trakt"
+
+  # Install and configure plugin
+  - name: "Trakt"
+    configuration:
+      TraktUsers:
+        - ExtraLogging: true
+
+  # Multiple plugins
+  - name: "Playback Reporting"
+  - name: "Fanart"
+    configuration:
+      EnableImages: true
+```
+
+**How it works:**
+
+- Plugins are installed from repositories configured in
+  `system.pluginRepositories`
+- Plugin names must match exactly (case-sensitive)
+- The `configuration` field accepts arbitrary key-value pairs specific to each
+  plugin
+- Only specified configuration fields are updated; unspecified fields are
+  preserved
+- Plugin configurations are applied after installation, allowing newly installed
+  plugins to be configured in the same run
+
+**Finding plugin configuration keys:**
+
+To discover available configuration options for a plugin, you can query the
+Jellyfin API:
+
+```bash
+# Get plugin ID
+curl -s -H "X-Emby-Token: $API_KEY" \
+  "http://localhost:8096/Plugins" | jq '.[] | select(.Name == "Trakt")'
+
+# Get plugin configuration
+curl -s -H "X-Emby-Token: $API_KEY" \
+  "http://localhost:8096/Plugins/{pluginId}/Configuration"
+```
+
 ---
 
 ## Secret Management
@@ -448,6 +497,12 @@ users:
     policy:
       isAdministrator: true
       loginAttemptsBeforeLockout: 3
+plugins:
+  - name: "Trakt"
+    configuration:
+      TraktUsers:
+        - ExtraLogging: true
+  - name: "Playback Reporting"
 startup:
   completeStartupWizard: true
 ```

--- a/config.yml
+++ b/config.yml
@@ -51,3 +51,6 @@ startup:
   completeStartupWizard: true
 plugins:
   - name: "Trakt"
+    configuration:
+      TraktUsers:
+        - ExtraLogging: true

--- a/config.yml
+++ b/config.yml
@@ -49,3 +49,5 @@ users:
     password: "plainpass"
 startup:
   completeStartupWizard: true
+plugins:
+  - name: "Trakt"

--- a/src/api/jellyfin.types.ts
+++ b/src/api/jellyfin.types.ts
@@ -11,6 +11,7 @@ import type {
   CreateUserByNameSchema,
   UserPolicySchema,
 } from "../types/schema/users";
+import { type PluginInfoSchema } from "../types/schema/plugins";
 
 export interface ApiResponse<T = unknown> {
   data?: T;
@@ -31,6 +32,8 @@ export type GetUsersResponse = ApiResponse<UserDtoSchema[]>;
 export type PostNewUserResponse = ApiResponse<UserDtoSchema>;
 export type PostUserPolicyResponse = ApiResponse<void>;
 export type PostStartupCompleteResponse = ApiResponse<void>;
+export type GetPluginsResponse = ApiResponse<PluginInfoSchema[]>;
+export type PostInstallPackageResponse = ApiResponse<void>;
 
 export interface JellyfinClient {
   getSystemConfiguration(): Promise<ServerConfigurationSchema>;
@@ -55,4 +58,6 @@ export interface JellyfinClient {
   createUser(body: CreateUserByNameSchema): Promise<void>;
   updateUserPolicy(userId: string, body: UserPolicySchema): Promise<void>;
   completeStartupWizard(): Promise<void>;
+  getPlugins(): Promise<PluginInfoSchema[]>;
+  installPackage(name: string): Promise<void>;
 }

--- a/src/api/jellyfin.types.ts
+++ b/src/api/jellyfin.types.ts
@@ -11,7 +11,10 @@ import type {
   CreateUserByNameSchema,
   UserPolicySchema,
 } from "../types/schema/users";
-import { type PluginInfoSchema } from "../types/schema/plugins";
+import {
+  type PluginInfoSchema,
+  type BasePluginConfigurationSchema,
+} from "../types/schema/plugins";
 
 export interface ApiResponse<T = unknown> {
   data?: T;
@@ -34,6 +37,9 @@ export type PostUserPolicyResponse = ApiResponse<void>;
 export type PostStartupCompleteResponse = ApiResponse<void>;
 export type GetPluginsResponse = ApiResponse<PluginInfoSchema[]>;
 export type PostInstallPackageResponse = ApiResponse<void>;
+export type GetPluginConfigurationResponse =
+  ApiResponse<BasePluginConfigurationSchema>;
+export type PostPluginConfigurationResponse = ApiResponse<void>;
 
 export interface JellyfinClient {
   getSystemConfiguration(): Promise<ServerConfigurationSchema>;
@@ -60,4 +66,11 @@ export interface JellyfinClient {
   completeStartupWizard(): Promise<void>;
   getPlugins(): Promise<PluginInfoSchema[]>;
   installPackage(name: string): Promise<void>;
+  getPluginConfiguration(
+    pluginId: string,
+  ): Promise<BasePluginConfigurationSchema>;
+  updatePluginConfiguration(
+    pluginId: string,
+    body: BasePluginConfigurationSchema,
+  ): Promise<void>;
 }

--- a/src/api/jellyfin_client.ts
+++ b/src/api/jellyfin_client.ts
@@ -27,11 +27,16 @@ import type {
   PostStartupCompleteResponse,
   GetPluginsResponse,
   PostInstallPackageResponse,
+  GetPluginConfigurationResponse,
+  PostPluginConfigurationResponse,
 } from "./jellyfin.types";
 import { makeClient } from "./client";
 import type { paths } from "../../generated/schema";
 import type { Client } from "openapi-fetch";
-import { type PluginInfoSchema } from "../types/schema/plugins";
+import {
+  type PluginInfoSchema,
+  type BasePluginConfigurationSchema,
+} from "../types/schema/plugins";
 
 export function createJellyfinClient(
   baseUrl: string,
@@ -260,6 +265,41 @@ export function createJellyfinClient(
       if (res.error) {
         throw new Error(
           `POST /Packages/Installed/${name} failed: ${res.response.status.toString()}`,
+        );
+      }
+    },
+
+    async getPluginConfiguration(
+      pluginId: string,
+    ): Promise<BasePluginConfigurationSchema> {
+      const res: GetPluginConfigurationResponse = await client.GET(
+        "/Plugins/{pluginId}/Configuration",
+        {
+          params: { path: { pluginId } },
+        },
+      );
+      if (res.error) {
+        throw new Error(
+          `GET /Plugins/${pluginId}/Configuration failed: ${res.response.status.toString()}`,
+        );
+      }
+      return res.data as BasePluginConfigurationSchema;
+    },
+
+    async updatePluginConfiguration(
+      pluginId: string,
+      body: BasePluginConfigurationSchema,
+    ): Promise<void> {
+      const res: PostPluginConfigurationResponse = await client.POST(
+        "/Plugins/{pluginId}/Configuration",
+        {
+          params: { path: { pluginId } },
+          body,
+        } as unknown as { params: { path: { pluginId: string } } },
+      );
+      if (res.error) {
+        throw new Error(
+          `POST /Plugins/${pluginId}/Configuration failed: ${res.response.status.toString()}`,
         );
       }
     },

--- a/src/api/jellyfin_client.ts
+++ b/src/api/jellyfin_client.ts
@@ -25,10 +25,13 @@ import type {
   PostNewUserResponse,
   PostUserPolicyResponse,
   PostStartupCompleteResponse,
+  GetPluginsResponse,
+  PostInstallPackageResponse,
 } from "./jellyfin.types";
 import { makeClient } from "./client";
 import type { paths } from "../../generated/schema";
 import type { Client } from "openapi-fetch";
+import { type PluginInfoSchema } from "../types/schema/plugins";
 
 export function createJellyfinClient(
   baseUrl: string,
@@ -233,6 +236,30 @@ export function createJellyfinClient(
       if (res.error) {
         throw new Error(
           `POST /Startup/Complete failed: ${res.response.status.toString()}`,
+        );
+      }
+    },
+
+    async getPlugins(): Promise<PluginInfoSchema[]> {
+      const res: GetPluginsResponse = await client.GET("/Plugins");
+      if (res.error) {
+        throw new Error(
+          `GET /Plugins failed: ${res.response.status.toString()}`,
+        );
+      }
+      return res.data as PluginInfoSchema[];
+    },
+
+    async installPackage(name: string): Promise<void> {
+      const res: PostInstallPackageResponse = await client.POST(
+        "/Packages/Installed/{name}",
+        {
+          params: { path: { name } },
+        },
+      );
+      if (res.error) {
+        throw new Error(
+          `POST /Packages/Installed/${name} failed: ${res.response.status.toString()}`,
         );
       }
     },

--- a/src/apply/plugins.ts
+++ b/src/apply/plugins.ts
@@ -1,0 +1,35 @@
+import { logger } from "../lib/logger";
+import type { JellyfinClient } from "../api/jellyfin.types";
+import type { PluginConfig, PluginConfigList } from "../types/config/plugins";
+import type { PluginInfoSchema } from "../types/schema/plugins";
+
+export function calculatePluginsToInstall(
+  installedPlugins: PluginInfoSchema[],
+  desired: PluginConfigList,
+): PluginConfig[] | undefined {
+  if (desired.length === 0) return undefined;
+
+  const pluginsToInstall: PluginConfig[] = desired.filter(
+    (desiredPlugin: PluginConfig) =>
+      !installedPlugins.find(
+        (plugin: PluginInfoSchema) => plugin.Name === desiredPlugin.name,
+      ),
+  );
+
+  pluginsToInstall.forEach((plugin: PluginConfig) => {
+    logger.info(`Installing plugin: ${plugin.name}`);
+  });
+
+  return pluginsToInstall.length > 0 ? pluginsToInstall : undefined;
+}
+
+export async function installPlugins(
+  client: JellyfinClient,
+  plugins: PluginConfig[] | undefined,
+): Promise<void> {
+  if (!plugins) return;
+
+  for (const plugin of plugins) {
+    await client.installPackage(plugin.name);
+  }
+}

--- a/src/apply/plugins.ts
+++ b/src/apply/plugins.ts
@@ -1,7 +1,17 @@
 import { logger } from "../lib/logger";
 import type { JellyfinClient } from "../api/jellyfin.types";
-import type { PluginConfig, PluginConfigList } from "../types/config/plugins";
-import type { PluginInfoSchema } from "../types/schema/plugins";
+import type {
+  PluginConfig,
+  PluginConfigList,
+  PluginConfigurationConfig,
+} from "../types/config/plugins";
+import type {
+  PluginInfoSchema,
+  BasePluginConfigurationSchema,
+  PluginConfigurationSchema,
+} from "../types/schema/plugins";
+import { ChangeSetBuilder } from "../lib/changeset";
+import { applyChangeset, diff, type IChange } from "json-diff-ts";
 
 export function calculatePluginsToInstall(
   installedPlugins: PluginInfoSchema[],
@@ -31,5 +41,97 @@ export async function installPlugins(
 
   for (const plugin of plugins) {
     await client.installPackage(plugin.name);
+  }
+}
+
+export async function getPluginConfigurationSchemaByName(
+  client: JellyfinClient,
+  current: PluginInfoSchema[],
+): Promise<Map<string, PluginConfigurationSchema>> {
+  const pluginConfigurationSchemaByName: Map<
+    string,
+    PluginConfigurationSchema
+  > = new Map();
+
+  for (const pluginInfo of current) {
+    if (pluginInfo.Id && pluginInfo.Name) {
+      pluginConfigurationSchemaByName.set(pluginInfo.Name, {
+        id: pluginInfo.Id,
+        configuration: await client.getPluginConfiguration(pluginInfo.Id),
+      });
+    }
+  }
+
+  return pluginConfigurationSchemaByName;
+}
+
+export function calculatePluginConfigurationDiff(
+  current: BasePluginConfigurationSchema,
+  desired: PluginConfigurationConfig,
+): BasePluginConfigurationSchema | undefined {
+  const patch: IChange[] = new ChangeSetBuilder(
+    diff(current, desired as BasePluginConfigurationSchema),
+  )
+    .atomize()
+    .withoutRemoves()
+    .unatomize()
+    .toArray();
+
+  if (patch.length > 0) {
+    return applyChangeset(current, patch) as BasePluginConfigurationSchema;
+  }
+
+  return undefined;
+}
+
+export function calculatePluginConfigurationsDiff(
+  currentPluginConfigurationsByName: Map<string, PluginConfigurationSchema>,
+  desired: PluginConfigList,
+): Map<string, BasePluginConfigurationSchema> | undefined {
+  if (desired.length === 0) return undefined;
+
+  const pluginConfigurationsToUpdate: Map<
+    string,
+    BasePluginConfigurationSchema
+  > = new Map();
+
+  desired.forEach((desiredPluginConfiguration: PluginConfig) => {
+    if (desiredPluginConfiguration.configuration) {
+      const currentPluginConfiguration: PluginConfigurationSchema | undefined =
+        currentPluginConfigurationsByName.get(desiredPluginConfiguration.name);
+
+      if (currentPluginConfiguration) {
+        const configurationDiff: BasePluginConfigurationSchema | undefined =
+          calculatePluginConfigurationDiff(
+            currentPluginConfiguration.configuration,
+            desiredPluginConfiguration.configuration,
+          );
+
+        if (configurationDiff) {
+          logger.info(
+            `Updating plugin configuration: ${desiredPluginConfiguration.name}`,
+          );
+          pluginConfigurationsToUpdate.set(
+            currentPluginConfiguration.id,
+            configurationDiff,
+          );
+        }
+      }
+    }
+  });
+
+  return pluginConfigurationsToUpdate.size > 0
+    ? pluginConfigurationsToUpdate
+    : undefined;
+}
+
+export async function applyPluginConfigurations(
+  client: JellyfinClient,
+  configurations: Map<string, BasePluginConfigurationSchema> | undefined,
+): Promise<void> {
+  if (!configurations) return;
+
+  for (const [pluginId, config] of configurations) {
+    await client.updatePluginConfiguration(pluginId, config);
   }
 }

--- a/src/types/config/plugins.ts
+++ b/src/types/config/plugins.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+export const PluginConfigType: z.ZodObject<{
+  name: z.ZodString;
+}> = z
+  .object({
+    name: z.string().min(1, "Plugin name cannot be empty"),
+  })
+  .strict();
+
+export type PluginConfig = z.infer<typeof PluginConfigType>;
+
+export const PluginConfigListType: z.ZodArray<typeof PluginConfigType> =
+  z.array(PluginConfigType);
+
+export type PluginConfigList = z.infer<typeof PluginConfigListType>;

--- a/src/types/config/plugins.ts
+++ b/src/types/config/plugins.ts
@@ -1,10 +1,21 @@
 import { z } from "zod";
 
+export const PluginConfigurationConfigType: z.ZodRecord<
+  z.ZodString,
+  z.ZodUnknown
+> = z.record(z.string(), z.unknown());
+
+export type PluginConfigurationConfig = z.infer<
+  typeof PluginConfigurationConfigType
+>;
+
 export const PluginConfigType: z.ZodObject<{
   name: z.ZodString;
+  configuration: z.ZodOptional<typeof PluginConfigurationConfigType>;
 }> = z
   .object({
     name: z.string().min(1, "Plugin name cannot be empty"),
+    configuration: PluginConfigurationConfigType.optional(),
   })
   .strict();
 

--- a/src/types/config/root.ts
+++ b/src/types/config/root.ts
@@ -5,6 +5,7 @@ import { LibraryConfigType } from "./library";
 import { BrandingOptionsConfigType } from "./branding-options";
 import { UserConfigListType } from "./users";
 import { StartupConfigType } from "./startup";
+import { PluginConfigListType } from "./plugins";
 
 export const RootConfigType: z.ZodObject<{
   version: z.ZodNumber;
@@ -14,6 +15,7 @@ export const RootConfigType: z.ZodObject<{
   library: z.ZodOptional<typeof LibraryConfigType>;
   branding: z.ZodOptional<typeof BrandingOptionsConfigType>;
   users: z.ZodOptional<typeof UserConfigListType>;
+  plugins: z.ZodOptional<typeof PluginConfigListType>;
   startup: z.ZodOptional<typeof StartupConfigType>;
 }> = z
   .object({
@@ -24,6 +26,7 @@ export const RootConfigType: z.ZodObject<{
     library: LibraryConfigType.optional(),
     branding: BrandingOptionsConfigType.optional(),
     users: UserConfigListType.optional(),
+    plugins: PluginConfigListType.optional(),
     startup: StartupConfigType.optional(),
   })
   .strict();

--- a/src/types/schema/plugins.ts
+++ b/src/types/schema/plugins.ts
@@ -2,3 +2,9 @@ import type { components } from "../../../generated/schema";
 
 export type PluginInfoSchema = components["schemas"]["PluginInfo"];
 export type PackageInfoSchema = components["schemas"]["PackageInfo"];
+export type BasePluginConfigurationSchema =
+  components["schemas"]["BasePluginConfiguration"];
+export interface PluginConfigurationSchema {
+  id: string;
+  configuration: BasePluginConfigurationSchema;
+}

--- a/src/types/schema/plugins.ts
+++ b/src/types/schema/plugins.ts
@@ -1,0 +1,4 @@
+import type { components } from "../../../generated/schema";
+
+export type PluginInfoSchema = components["schemas"]["PluginInfo"];
+export type PackageInfoSchema = components["schemas"]["PackageInfo"];

--- a/tests/apply/plugins.spec.ts
+++ b/tests/apply/plugins.spec.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import {
+  calculatePluginsToInstall,
+  installPlugins,
+} from "../../src/apply/plugins";
+import type { JellyfinClient } from "../../src/api/jellyfin.types";
+import type {
+  PluginConfig,
+  PluginConfigList,
+} from "../../src/types/config/plugins";
+import type { PluginInfoSchema } from "../../src/types/schema/plugins";
+
+vi.mock("../../src/lib/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("calculatePluginsToInstall", () => {
+  const installedPlugins: PluginInfoSchema[] = [
+    {
+      Name: "Trakt",
+      Version: "26.0.0",
+      Id: "plugin-1-id",
+      Status: "Active",
+    } as PluginInfoSchema,
+    {
+      Name: "Playback Reporting",
+      Version: "10.0.0",
+      Id: "plugin-2-id",
+      Status: "Active",
+    } as PluginInfoSchema,
+  ];
+
+  it("should return undefined when no plugins desired", () => {
+    // Arrange
+    const config: PluginConfigList = [];
+
+    // Act
+    const result: PluginConfig[] | undefined = calculatePluginsToInstall(
+      installedPlugins,
+      config,
+    );
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+
+  it("should return undefined when all desired plugins already installed", () => {
+    // Arrange
+    const config: PluginConfigList = [
+      { name: "Trakt" },
+      { name: "Playback Reporting" },
+    ];
+
+    // Act
+    const result: PluginConfig[] | undefined = calculatePluginsToInstall(
+      installedPlugins,
+      config,
+    );
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+
+  it("should return plugins to install when new plugins desired", () => {
+    // Arrange
+    const config: PluginConfigList = [{ name: "Trakt" }, { name: "Fanart" }];
+
+    // Act
+    const result: PluginConfig[] | undefined = calculatePluginsToInstall(
+      installedPlugins,
+      config,
+    );
+
+    // Assert
+    expect(result).toBeDefined();
+    expect(result).toHaveLength(1);
+    expect(result?.[0]).toEqual({ name: "Fanart" });
+  });
+
+  it("should return multiple plugins when multiple new plugins desired", () => {
+    // Arrange
+    const config: PluginConfigList = [
+      { name: "Fanart" },
+      { name: "TMDb Box Sets" },
+    ];
+
+    // Act
+    const result: PluginConfig[] | undefined = calculatePluginsToInstall(
+      installedPlugins,
+      config,
+    );
+
+    // Assert
+    expect(result).toBeDefined();
+    expect(result).toHaveLength(2);
+    expect(result?.[0]).toEqual({ name: "Fanart" });
+    expect(result?.[1]).toEqual({ name: "TMDb Box Sets" });
+  });
+
+  it("should handle mixed existing and new plugins", () => {
+    // Arrange
+    const config: PluginConfigList = [
+      { name: "Trakt" },
+      { name: "Fanart" },
+      { name: "Playback Reporting" },
+      { name: "TMDb Box Sets" },
+    ];
+
+    // Act
+    const result: PluginConfig[] | undefined = calculatePluginsToInstall(
+      installedPlugins,
+      config,
+    );
+
+    // Assert
+    expect(result).toBeDefined();
+    expect(result).toHaveLength(2);
+    expect(result?.[0]).toEqual({ name: "Fanart" });
+    expect(result?.[1]).toEqual({ name: "TMDb Box Sets" });
+  });
+
+  it("should handle empty installed plugins list", () => {
+    // Arrange
+    const config: PluginConfigList = [{ name: "Trakt" }];
+
+    // Act
+    const result: PluginConfig[] | undefined = calculatePluginsToInstall(
+      [],
+      config,
+    );
+
+    // Assert
+    expect(result).toBeDefined();
+    expect(result).toHaveLength(1);
+    expect(result?.[0]).toEqual({ name: "Trakt" });
+  });
+
+  it("should handle order-independent comparison", () => {
+    // Arrange
+    const config: PluginConfigList = [
+      { name: "Playback Reporting" },
+      { name: "Trakt" },
+    ];
+
+    // Act
+    const result: PluginConfig[] | undefined = calculatePluginsToInstall(
+      installedPlugins,
+      config,
+    );
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+
+  it("should handle undefined plugin names in installed plugins", () => {
+    // Arrange
+    const installedWithUndefined: PluginInfoSchema[] = [
+      {
+        Name: undefined,
+        Id: "plugin-1-id",
+      } as PluginInfoSchema,
+      {
+        Name: "Trakt",
+        Id: "plugin-2-id",
+      } as PluginInfoSchema,
+    ];
+
+    const config: PluginConfigList = [{ name: "Trakt" }];
+
+    // Act
+    const result: PluginConfig[] | undefined = calculatePluginsToInstall(
+      installedWithUndefined,
+      config,
+    );
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+
+  it("should be case-sensitive when matching plugin names", () => {
+    // Arrange
+    const config: PluginConfigList = [{ name: "trakt" }];
+
+    // Act
+    const result: PluginConfig[] | undefined = calculatePluginsToInstall(
+      installedPlugins,
+      config,
+    );
+
+    // Assert
+    expect(result).toBeDefined();
+    expect(result).toHaveLength(1);
+    expect(result?.[0]).toEqual({ name: "trakt" });
+  });
+});
+
+describe("installPlugins", () => {
+  let mockClient: JellyfinClient;
+  let installPackageSpy: Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    installPackageSpy = vi.fn();
+    mockClient = {
+      installPackage: installPackageSpy,
+    } as unknown as JellyfinClient;
+  });
+
+  it("should do nothing when plugins is undefined", async () => {
+    // Act
+    await installPlugins(mockClient, undefined);
+
+    // Assert
+    expect(installPackageSpy).not.toHaveBeenCalled();
+  });
+
+  it("should install single plugin", async () => {
+    // Arrange
+    const pluginsToInstall: PluginConfig[] = [{ name: "Trakt" }];
+    installPackageSpy.mockResolvedValue(undefined);
+
+    // Act
+    await installPlugins(mockClient, pluginsToInstall);
+
+    // Assert
+    expect(installPackageSpy).toHaveBeenCalledTimes(1);
+    expect(installPackageSpy).toHaveBeenCalledWith("Trakt");
+  });
+
+  it("should install multiple plugins", async () => {
+    // Arrange
+    const pluginsToInstall: PluginConfig[] = [
+      { name: "Trakt" },
+      { name: "Fanart" },
+      { name: "Playback Reporting" },
+    ];
+    installPackageSpy.mockResolvedValue(undefined);
+
+    // Act
+    await installPlugins(mockClient, pluginsToInstall);
+
+    // Assert
+    expect(installPackageSpy).toHaveBeenCalledTimes(3);
+    expect(installPackageSpy).toHaveBeenNthCalledWith(1, "Trakt");
+    expect(installPackageSpy).toHaveBeenNthCalledWith(2, "Fanart");
+    expect(installPackageSpy).toHaveBeenNthCalledWith(3, "Playback Reporting");
+  });
+
+  it("should handle empty plugins list", async () => {
+    // Arrange
+    const pluginsToInstall: PluginConfig[] = [];
+
+    // Act
+    await installPlugins(mockClient, pluginsToInstall);
+
+    // Assert
+    expect(installPackageSpy).not.toHaveBeenCalled();
+  });
+
+  it("should install plugins with spaces in name", async () => {
+    // Arrange
+    const pluginsToInstall: PluginConfig[] = [
+      { name: "Playback Reporting" },
+      { name: "TMDb Box Sets" },
+    ];
+    installPackageSpy.mockResolvedValue(undefined);
+
+    // Act
+    await installPlugins(mockClient, pluginsToInstall);
+
+    // Assert
+    expect(installPackageSpy).toHaveBeenCalledTimes(2);
+    expect(installPackageSpy).toHaveBeenNthCalledWith(1, "Playback Reporting");
+    expect(installPackageSpy).toHaveBeenNthCalledWith(2, "TMDb Box Sets");
+  });
+});

--- a/tests/apply/plugins.spec.ts
+++ b/tests/apply/plugins.spec.ts
@@ -2,13 +2,22 @@ import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 import {
   calculatePluginsToInstall,
   installPlugins,
+  getPluginConfigurationSchemaByName,
+  calculatePluginConfigurationDiff,
+  calculatePluginConfigurationsDiff,
+  applyPluginConfigurations,
 } from "../../src/apply/plugins";
 import type { JellyfinClient } from "../../src/api/jellyfin.types";
 import type {
   PluginConfig,
   PluginConfigList,
+  PluginConfigurationConfig,
 } from "../../src/types/config/plugins";
-import type { PluginInfoSchema } from "../../src/types/schema/plugins";
+import type {
+  PluginInfoSchema,
+  BasePluginConfigurationSchema,
+  PluginConfigurationSchema,
+} from "../../src/types/schema/plugins";
 
 vi.mock("../../src/lib/logger", () => ({
   logger: {
@@ -276,5 +285,477 @@ describe("installPlugins", () => {
     expect(installPackageSpy).toHaveBeenCalledTimes(2);
     expect(installPackageSpy).toHaveBeenNthCalledWith(1, "Playback Reporting");
     expect(installPackageSpy).toHaveBeenNthCalledWith(2, "TMDb Box Sets");
+  });
+});
+
+describe("getPluginConfigurationSchemaByName", () => {
+  let mockClient: JellyfinClient;
+  let getPluginConfigurationSpy: Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getPluginConfigurationSpy = vi.fn();
+    mockClient = {
+      getPluginConfiguration: getPluginConfigurationSpy,
+    } as unknown as JellyfinClient;
+  });
+
+  it("should return empty map when no plugins", async () => {
+    // Arrange
+    const installedPlugins: PluginInfoSchema[] = [];
+
+    // Act
+    const result: Map<string, PluginConfigurationSchema> =
+      await getPluginConfigurationSchemaByName(mockClient, installedPlugins);
+
+    // Assert
+    expect(result.size).toBe(0);
+    expect(getPluginConfigurationSpy).not.toHaveBeenCalled();
+  });
+
+  it("should return map with plugin configurations", async () => {
+    // Arrange
+    const installedPlugins: PluginInfoSchema[] = [
+      { Name: "Trakt", Id: "trakt-id" } as PluginInfoSchema,
+      { Name: "Fanart", Id: "fanart-id" } as PluginInfoSchema,
+    ];
+    const traktConfig: BasePluginConfigurationSchema = {
+      TraktUsers: [],
+    } as unknown as BasePluginConfigurationSchema;
+    const fanartConfig: BasePluginConfigurationSchema = {
+      EnableImages: true,
+    } as unknown as BasePluginConfigurationSchema;
+    getPluginConfigurationSpy
+      .mockResolvedValueOnce(traktConfig)
+      .mockResolvedValueOnce(fanartConfig);
+
+    // Act
+    const result: Map<string, PluginConfigurationSchema> =
+      await getPluginConfigurationSchemaByName(mockClient, installedPlugins);
+
+    // Assert
+    expect(result.size).toBe(2);
+    expect(result.get("Trakt")).toEqual({
+      id: "trakt-id",
+      configuration: traktConfig,
+    });
+    expect(result.get("Fanart")).toEqual({
+      id: "fanart-id",
+      configuration: fanartConfig,
+    });
+    expect(getPluginConfigurationSpy).toHaveBeenCalledTimes(2);
+    expect(getPluginConfigurationSpy).toHaveBeenCalledWith("trakt-id");
+    expect(getPluginConfigurationSpy).toHaveBeenCalledWith("fanart-id");
+  });
+
+  it("should skip plugins without Id", async () => {
+    // Arrange
+    const installedPlugins: PluginInfoSchema[] = [
+      { Name: "Trakt", Id: undefined } as PluginInfoSchema,
+      { Name: "Fanart", Id: "fanart-id" } as PluginInfoSchema,
+    ];
+    const fanartConfig: BasePluginConfigurationSchema = {
+      EnableImages: true,
+    } as unknown as BasePluginConfigurationSchema;
+    getPluginConfigurationSpy.mockResolvedValueOnce(fanartConfig);
+
+    // Act
+    const result: Map<string, PluginConfigurationSchema> =
+      await getPluginConfigurationSchemaByName(mockClient, installedPlugins);
+
+    // Assert
+    expect(result.size).toBe(1);
+    expect(result.get("Fanart")).toEqual({
+      id: "fanart-id",
+      configuration: fanartConfig,
+    });
+    expect(getPluginConfigurationSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("should skip plugins without Name", async () => {
+    // Arrange
+    const installedPlugins: PluginInfoSchema[] = [
+      { Name: undefined, Id: "trakt-id" } as PluginInfoSchema,
+      { Name: "Fanart", Id: "fanart-id" } as PluginInfoSchema,
+    ];
+    const fanartConfig: BasePluginConfigurationSchema = {
+      EnableImages: true,
+    } as unknown as BasePluginConfigurationSchema;
+    getPluginConfigurationSpy.mockResolvedValueOnce(fanartConfig);
+
+    // Act
+    const result: Map<string, PluginConfigurationSchema> =
+      await getPluginConfigurationSchemaByName(mockClient, installedPlugins);
+
+    // Assert
+    expect(result.size).toBe(1);
+    expect(result.get("Fanart")).toEqual({
+      id: "fanart-id",
+      configuration: fanartConfig,
+    });
+    expect(getPluginConfigurationSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("calculatePluginConfigurationDiff", () => {
+  it("should return undefined when no changes", () => {
+    // Arrange
+    const current: BasePluginConfigurationSchema = {
+      TraktUsers: [{ ExtraLogging: false }],
+    } as unknown as BasePluginConfigurationSchema;
+    const desired: PluginConfigurationConfig = {
+      TraktUsers: [{ ExtraLogging: false }],
+    };
+
+    // Act
+    const result: BasePluginConfigurationSchema | undefined =
+      calculatePluginConfigurationDiff(current, desired);
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+
+  it("should return updated schema when field changes", () => {
+    // Arrange
+    const current: BasePluginConfigurationSchema = {
+      TraktUsers: [{ ExtraLogging: false }],
+    } as unknown as BasePluginConfigurationSchema;
+    const desired: PluginConfigurationConfig = {
+      TraktUsers: [{ ExtraLogging: true }],
+    };
+
+    // Act
+    const result: BasePluginConfigurationSchema | undefined =
+      calculatePluginConfigurationDiff(current, desired);
+
+    // Assert
+    expect(result).toBeDefined();
+    expect((result as unknown as Record<string, unknown>).TraktUsers).toEqual([
+      { ExtraLogging: true },
+    ]);
+  });
+
+  it("should preserve existing fields not in desired", () => {
+    // Arrange
+    const current: BasePluginConfigurationSchema = {
+      TraktUsers: [{ ExtraLogging: false }],
+      OtherField: "preserved",
+    } as unknown as BasePluginConfigurationSchema;
+    const desired: PluginConfigurationConfig = {
+      TraktUsers: [{ ExtraLogging: true }],
+    };
+
+    // Act
+    const result: BasePluginConfigurationSchema | undefined =
+      calculatePluginConfigurationDiff(current, desired);
+
+    // Assert
+    expect(result).toBeDefined();
+    const resultRecord: Record<string, unknown> = result as unknown as Record<
+      string,
+      unknown
+    >;
+    expect(resultRecord.TraktUsers).toEqual([{ ExtraLogging: true }]);
+    expect(resultRecord.OtherField).toBe("preserved");
+  });
+
+  it("should add new fields from desired", () => {
+    // Arrange
+    const current: BasePluginConfigurationSchema = {
+      ExistingField: "value",
+    } as unknown as BasePluginConfigurationSchema;
+    const desired: PluginConfigurationConfig = {
+      NewField: "new value",
+    };
+
+    // Act
+    const result: BasePluginConfigurationSchema | undefined =
+      calculatePluginConfigurationDiff(current, desired);
+
+    // Assert
+    expect(result).toBeDefined();
+    const resultRecord: Record<string, unknown> = result as unknown as Record<
+      string,
+      unknown
+    >;
+    expect(resultRecord.ExistingField).toBe("value");
+    expect(resultRecord.NewField).toBe("new value");
+  });
+
+  it("should handle nested object changes", () => {
+    // Arrange
+    const current: BasePluginConfigurationSchema = {
+      Settings: { Option1: true, Option2: false },
+    } as unknown as BasePluginConfigurationSchema;
+    const desired: PluginConfigurationConfig = {
+      Settings: { Option1: false },
+    };
+
+    // Act
+    const result: BasePluginConfigurationSchema | undefined =
+      calculatePluginConfigurationDiff(current, desired);
+
+    // Assert
+    expect(result).toBeDefined();
+    const resultRecord: Record<
+      string,
+      Record<string, boolean>
+    > = result as unknown as Record<string, Record<string, boolean>>;
+    expect(resultRecord.Settings.Option1).toBe(false);
+    expect(resultRecord.Settings.Option2).toBe(false);
+  });
+});
+
+describe("calculatePluginConfigurationsDiff", () => {
+  it("should return undefined when no plugins desired", () => {
+    // Arrange
+    const currentMap: Map<string, PluginConfigurationSchema> = new Map([
+      [
+        "Trakt",
+        {
+          id: "trakt-id",
+          configuration: {
+            TraktUsers: [],
+          } as unknown as BasePluginConfigurationSchema,
+        },
+      ],
+    ]);
+    const desired: PluginConfigList = [];
+
+    // Act
+    const result: Map<string, BasePluginConfigurationSchema> | undefined =
+      calculatePluginConfigurationsDiff(currentMap, desired);
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+
+  it("should return undefined when no plugins have configuration", () => {
+    // Arrange
+    const currentMap: Map<string, PluginConfigurationSchema> = new Map([
+      [
+        "Trakt",
+        {
+          id: "trakt-id",
+          configuration: {
+            TraktUsers: [],
+          } as unknown as BasePluginConfigurationSchema,
+        },
+      ],
+    ]);
+    const desired: PluginConfigList = [{ name: "Trakt" }];
+
+    // Act
+    const result: Map<string, BasePluginConfigurationSchema> | undefined =
+      calculatePluginConfigurationsDiff(currentMap, desired);
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+
+  it("should return undefined when plugin not installed", () => {
+    // Arrange
+    const currentMap: Map<string, PluginConfigurationSchema> = new Map();
+    const desired: PluginConfigList = [
+      { name: "Trakt", configuration: { TraktUsers: [] } },
+    ];
+
+    // Act
+    const result: Map<string, BasePluginConfigurationSchema> | undefined =
+      calculatePluginConfigurationsDiff(currentMap, desired);
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+
+  it("should return undefined when configuration unchanged", () => {
+    // Arrange
+    const currentMap: Map<string, PluginConfigurationSchema> = new Map([
+      [
+        "Trakt",
+        {
+          id: "trakt-id",
+          configuration: {
+            TraktUsers: [{ ExtraLogging: true }],
+          } as unknown as BasePluginConfigurationSchema,
+        },
+      ],
+    ]);
+    const desired: PluginConfigList = [
+      {
+        name: "Trakt",
+        configuration: { TraktUsers: [{ ExtraLogging: true }] },
+      },
+    ];
+
+    // Act
+    const result: Map<string, BasePluginConfigurationSchema> | undefined =
+      calculatePluginConfigurationsDiff(currentMap, desired);
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+
+  it("should return map with updated configurations", () => {
+    // Arrange
+    const currentMap: Map<string, PluginConfigurationSchema> = new Map([
+      [
+        "Trakt",
+        {
+          id: "trakt-id",
+          configuration: {
+            TraktUsers: [{ ExtraLogging: false }],
+          } as unknown as BasePluginConfigurationSchema,
+        },
+      ],
+    ]);
+    const desired: PluginConfigList = [
+      {
+        name: "Trakt",
+        configuration: { TraktUsers: [{ ExtraLogging: true }] },
+      },
+    ];
+
+    // Act
+    const result: Map<string, BasePluginConfigurationSchema> | undefined =
+      calculatePluginConfigurationsDiff(currentMap, desired);
+
+    // Assert
+    expect(result).toBeDefined();
+    expect(result?.size).toBe(1);
+    const config: Record<string, unknown> = result?.get(
+      "trakt-id",
+    ) as unknown as Record<string, unknown>;
+    expect(config.TraktUsers).toEqual([{ ExtraLogging: true }]);
+  });
+
+  it("should handle multiple plugins with changes", () => {
+    // Arrange
+    const currentMap: Map<string, PluginConfigurationSchema> = new Map([
+      [
+        "Trakt",
+        {
+          id: "trakt-id",
+          configuration: {
+            TraktUsers: [{ ExtraLogging: false }],
+          } as unknown as BasePluginConfigurationSchema,
+        },
+      ],
+      [
+        "Fanart",
+        {
+          id: "fanart-id",
+          configuration: {
+            EnableImages: false,
+          } as unknown as BasePluginConfigurationSchema,
+        },
+      ],
+    ]);
+    const desired: PluginConfigList = [
+      {
+        name: "Trakt",
+        configuration: { TraktUsers: [{ ExtraLogging: true }] },
+      },
+      { name: "Fanart", configuration: { EnableImages: true } },
+    ];
+
+    // Act
+    const result: Map<string, BasePluginConfigurationSchema> | undefined =
+      calculatePluginConfigurationsDiff(currentMap, desired);
+
+    // Assert
+    expect(result).toBeDefined();
+    expect(result?.size).toBe(2);
+    const traktConfig: Record<string, unknown> = result?.get(
+      "trakt-id",
+    ) as unknown as Record<string, unknown>;
+    expect(traktConfig.TraktUsers).toEqual([{ ExtraLogging: true }]);
+    const fanartConfig: Record<string, unknown> = result?.get(
+      "fanart-id",
+    ) as unknown as Record<string, unknown>;
+    expect(fanartConfig.EnableImages).toBe(true);
+  });
+});
+
+describe("applyPluginConfigurations", () => {
+  let mockClient: JellyfinClient;
+  let updatePluginConfigurationSpy: Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    updatePluginConfigurationSpy = vi.fn();
+    mockClient = {
+      updatePluginConfiguration: updatePluginConfigurationSpy,
+    } as unknown as JellyfinClient;
+  });
+
+  it("should do nothing when configurations is undefined", async () => {
+    // Act
+    await applyPluginConfigurations(mockClient, undefined);
+
+    // Assert
+    expect(updatePluginConfigurationSpy).not.toHaveBeenCalled();
+  });
+
+  it("should update single plugin configuration", async () => {
+    // Arrange
+    const config: BasePluginConfigurationSchema = {
+      TraktUsers: [{ ExtraLogging: true }],
+    } as unknown as BasePluginConfigurationSchema;
+    const configurations: Map<string, BasePluginConfigurationSchema> = new Map([
+      ["trakt-id", config],
+    ]);
+    updatePluginConfigurationSpy.mockResolvedValue(undefined);
+
+    // Act
+    await applyPluginConfigurations(mockClient, configurations);
+
+    // Assert
+    expect(updatePluginConfigurationSpy).toHaveBeenCalledTimes(1);
+    expect(updatePluginConfigurationSpy).toHaveBeenCalledWith(
+      "trakt-id",
+      config,
+    );
+  });
+
+  it("should update multiple plugin configurations", async () => {
+    // Arrange
+    const traktConfig: BasePluginConfigurationSchema = {
+      TraktUsers: [{ ExtraLogging: true }],
+    } as unknown as BasePluginConfigurationSchema;
+    const fanartConfig: BasePluginConfigurationSchema = {
+      EnableImages: true,
+    } as unknown as BasePluginConfigurationSchema;
+    const configurations: Map<string, BasePluginConfigurationSchema> = new Map([
+      ["trakt-id", traktConfig],
+      ["fanart-id", fanartConfig],
+    ]);
+    updatePluginConfigurationSpy.mockResolvedValue(undefined);
+
+    // Act
+    await applyPluginConfigurations(mockClient, configurations);
+
+    // Assert
+    expect(updatePluginConfigurationSpy).toHaveBeenCalledTimes(2);
+    expect(updatePluginConfigurationSpy).toHaveBeenCalledWith(
+      "trakt-id",
+      traktConfig,
+    );
+    expect(updatePluginConfigurationSpy).toHaveBeenCalledWith(
+      "fanart-id",
+      fanartConfig,
+    );
+  });
+
+  it("should handle empty map", async () => {
+    // Arrange
+    const configurations: Map<string, BasePluginConfigurationSchema> =
+      new Map();
+
+    // Act
+    await applyPluginConfigurations(mockClient, configurations);
+
+    // Assert
+    expect(updatePluginConfigurationSpy).not.toHaveBeenCalled();
   });
 });

--- a/tests/types/config/plugins.spec.ts
+++ b/tests/types/config/plugins.spec.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest";
+import type { ZodSafeParseResult } from "zod";
+import { type z } from "zod";
+import {
+  PluginConfigType,
+  PluginConfigListType,
+  type PluginConfig,
+  type PluginConfigList,
+} from "../../../src/types/config/plugins";
+
+describe("PluginConfig", () => {
+  it("should validate plugin config with valid name", () => {
+    // Arrange
+    const validConfig: z.input<typeof PluginConfigType> = {
+      name: "Trakt",
+    };
+
+    // Act
+    const result: ZodSafeParseResult<PluginConfig> =
+      PluginConfigType.safeParse(validConfig);
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.name).toBe("Trakt");
+    }
+  });
+
+  it("should reject empty name", () => {
+    // Arrange
+    const invalidConfig: z.input<typeof PluginConfigType> = {
+      name: "",
+    };
+
+    // Act
+    const result: ZodSafeParseResult<PluginConfig> =
+      PluginConfigType.safeParse(invalidConfig);
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues).toBeDefined();
+      expect(result.error.issues.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("should reject missing name", () => {
+    // Arrange
+    const invalidConfig: Record<string, never> = {};
+
+    // Act
+    const result: ZodSafeParseResult<PluginConfig> =
+      PluginConfigType.safeParse(invalidConfig);
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues).toBeDefined();
+      expect(result.error.issues.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("should reject invalid name type", () => {
+    // Arrange
+    const invalidConfig: z.input<typeof PluginConfigType> = {
+      // @ts-expect-error intentional invalid value for test
+      name: 123,
+    };
+
+    // Act
+    const result: ZodSafeParseResult<PluginConfig> =
+      PluginConfigType.safeParse(invalidConfig);
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues).toBeDefined();
+      expect(result.error.issues.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("should reject extra fields due to strict mode", () => {
+    // Arrange
+    const invalidConfig: z.input<typeof PluginConfigType> = {
+      name: "Trakt",
+      // @ts-expect-error intentional extra field for test
+      extraField: "not allowed",
+    };
+
+    // Act
+    const result: ZodSafeParseResult<PluginConfig> =
+      PluginConfigType.safeParse(invalidConfig);
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues).toBeDefined();
+      const strictError: z.core.$ZodIssue | undefined =
+        result.error.issues.find(
+          (err: z.core.$ZodIssue) => err.code === "unrecognized_keys",
+        );
+      expect(strictError?.code).toBe("unrecognized_keys");
+    }
+  });
+});
+
+describe("PluginConfigList", () => {
+  it("should validate array of plugin configs", () => {
+    // Arrange
+    const validConfigs: z.input<typeof PluginConfigListType> = [
+      { name: "Trakt" },
+      { name: "Playback Reporting" },
+    ];
+
+    // Act
+    const result: ZodSafeParseResult<PluginConfigList> =
+      PluginConfigListType.safeParse(validConfigs);
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toHaveLength(2);
+      expect(result.data[0].name).toBe("Trakt");
+      expect(result.data[1].name).toBe("Playback Reporting");
+    }
+  });
+
+  it("should validate empty array", () => {
+    // Arrange
+    const validConfigs: z.input<typeof PluginConfigListType> = [];
+
+    // Act
+    const result: ZodSafeParseResult<PluginConfigList> =
+      PluginConfigListType.safeParse(validConfigs);
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toHaveLength(0);
+    }
+  });
+
+  it("should reject array with invalid plugin config", () => {
+    // Arrange
+    const invalidConfigs: Array<{ name: string }> = [
+      { name: "Trakt" },
+      { name: "" },
+    ];
+
+    // Act
+    const result: ZodSafeParseResult<PluginConfigList> =
+      PluginConfigListType.safeParse(invalidConfigs);
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues).toBeDefined();
+      expect(result.error.issues.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/tests/types/config/plugins.spec.ts
+++ b/tests/types/config/plugins.spec.ts
@@ -102,6 +102,73 @@ describe("PluginConfig", () => {
       expect(strictError?.code).toBe("unrecognized_keys");
     }
   });
+
+  it("should validate plugin config with configuration field", () => {
+    // Arrange
+    const validConfig: z.input<typeof PluginConfigType> = {
+      name: "Trakt",
+      configuration: {
+        TraktUsers: [{ ExtraLogging: true }],
+      },
+    };
+
+    // Act
+    const result: ZodSafeParseResult<PluginConfig> =
+      PluginConfigType.safeParse(validConfig);
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.name).toBe("Trakt");
+      expect(result.data.configuration).toEqual({
+        TraktUsers: [{ ExtraLogging: true }],
+      });
+    }
+  });
+
+  it("should validate configuration with any key-value pairs", () => {
+    // Arrange
+    const validConfig: z.input<typeof PluginConfigType> = {
+      name: "SomePlugin",
+      configuration: {
+        stringValue: "test",
+        numberValue: 123,
+        booleanValue: true,
+        nestedObject: { key: "value" },
+        arrayValue: [1, 2, 3],
+      },
+    };
+
+    // Act
+    const result: ZodSafeParseResult<PluginConfig> =
+      PluginConfigType.safeParse(validConfig);
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.configuration?.stringValue).toBe("test");
+      expect(result.data.configuration?.numberValue).toBe(123);
+      expect(result.data.configuration?.booleanValue).toBe(true);
+    }
+  });
+
+  it("should validate plugin config without configuration (optional)", () => {
+    // Arrange
+    const validConfig: z.input<typeof PluginConfigType> = {
+      name: "Trakt",
+    };
+
+    // Act
+    const result: ZodSafeParseResult<PluginConfig> =
+      PluginConfigType.safeParse(validConfig);
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.name).toBe("Trakt");
+      expect(result.data.configuration).toBeUndefined();
+    }
+  });
 });
 
 describe("PluginConfigList", () => {
@@ -156,6 +223,29 @@ describe("PluginConfigList", () => {
     if (!result.success) {
       expect(result.error.issues).toBeDefined();
       expect(result.error.issues.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("should validate array with plugins containing configuration", () => {
+    // Arrange
+    const validConfigs: z.input<typeof PluginConfigListType> = [
+      {
+        name: "Trakt",
+        configuration: { TraktUsers: [{ ExtraLogging: true }] },
+      },
+      { name: "Playback Reporting" },
+    ];
+
+    // Act
+    const result: ZodSafeParseResult<PluginConfigList> =
+      PluginConfigListType.safeParse(validConfigs);
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toHaveLength(2);
+      expect(result.data[0].configuration).toBeDefined();
+      expect(result.data[1].configuration).toBeUndefined();
     }
   });
 });

--- a/tests/types/config/root.spec.ts
+++ b/tests/types/config/root.spec.ts
@@ -523,7 +523,12 @@ describe("RootConfig", () => {
           passwordFile: "/secrets/viewer_password",
         },
       ],
-      plugins: [{ name: "Trakt" }],
+      plugins: [
+        {
+          name: "Trakt",
+          configuration: { TraktUsers: [{ ExtraLogging: true }] },
+        },
+      ],
       startup: {
         completeStartupWizard: true,
       },
@@ -681,6 +686,35 @@ describe("RootConfig", () => {
       expect(result.data.plugins).toHaveLength(2);
       expect(result.data.plugins?.[0].name).toBe("Trakt");
       expect(result.data.plugins?.[1].name).toBe("Playback Reporting");
+    }
+  });
+
+  it("should validate root config with plugins containing configuration", () => {
+    // Arrange
+    const validConfig: z.input<typeof RootConfigType> = {
+      version: 1,
+      base_url: "http://10.0.0.76:8096",
+      system: {},
+      plugins: [
+        {
+          name: "Trakt",
+          configuration: { TraktUsers: [{ ExtraLogging: true }] },
+        },
+        { name: "Playback Reporting" },
+      ],
+    };
+
+    // Act
+    const result: ZodSafeParseResult<RootConfig> =
+      RootConfigType.safeParse(validConfig);
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.plugins).toBeDefined();
+      expect(result.data.plugins).toHaveLength(2);
+      expect(result.data.plugins?.[0].configuration).toBeDefined();
+      expect(result.data.plugins?.[1].configuration).toBeUndefined();
     }
   });
 

--- a/tests/types/config/root.spec.ts
+++ b/tests/types/config/root.spec.ts
@@ -523,6 +523,10 @@ describe("RootConfig", () => {
           passwordFile: "/secrets/viewer_password",
         },
       ],
+      plugins: [{ name: "Trakt" }],
+      startup: {
+        completeStartupWizard: true,
+      },
     };
 
     // Act
@@ -538,6 +542,9 @@ describe("RootConfig", () => {
       expect(result.data.branding).toBeDefined();
       expect(result.data.users).toBeDefined();
       expect(result.data.users).toHaveLength(2);
+      expect(result.data.plugins).toBeDefined();
+      expect(result.data.plugins).toHaveLength(1);
+      expect(result.data.startup).toBeDefined();
     }
   });
 
@@ -640,6 +647,90 @@ describe("RootConfig", () => {
         // @ts-expect-error intentional invalid field for test
         invalidField: "not allowed",
       },
+    };
+
+    // Act
+    const result: ZodSafeParseResult<RootConfig> =
+      RootConfigType.safeParse(invalidConfig);
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues).toBeDefined();
+      expect(result.error.issues.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("should validate root config with plugins section", () => {
+    // Arrange
+    const validConfig: z.input<typeof RootConfigType> = {
+      version: 1,
+      base_url: "http://10.0.0.76:8096",
+      system: {},
+      plugins: [{ name: "Trakt" }, { name: "Playback Reporting" }],
+    };
+
+    // Act
+    const result: ZodSafeParseResult<RootConfig> =
+      RootConfigType.safeParse(validConfig);
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.plugins).toBeDefined();
+      expect(result.data.plugins).toHaveLength(2);
+      expect(result.data.plugins?.[0].name).toBe("Trakt");
+      expect(result.data.plugins?.[1].name).toBe("Playback Reporting");
+    }
+  });
+
+  it("should validate root config with empty plugins section", () => {
+    // Arrange
+    const validConfig: z.input<typeof RootConfigType> = {
+      version: 1,
+      base_url: "http://10.0.0.76:8096",
+      system: {},
+      plugins: [],
+    };
+
+    // Act
+    const result: ZodSafeParseResult<RootConfig> =
+      RootConfigType.safeParse(validConfig);
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.plugins).toBeDefined();
+      expect(result.data.plugins).toHaveLength(0);
+    }
+  });
+
+  it("should validate root config without plugins section", () => {
+    // Arrange
+    const validConfig: z.input<typeof RootConfigType> = {
+      version: 1,
+      base_url: "http://10.0.0.76:8096",
+      system: {},
+    };
+
+    // Act
+    const result: ZodSafeParseResult<RootConfig> =
+      RootConfigType.safeParse(validConfig);
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.plugins).toBeUndefined();
+    }
+  });
+
+  it("should reject invalid plugins configuration", () => {
+    // Arrange
+    const invalidConfig: z.input<typeof RootConfigType> = {
+      version: 1,
+      base_url: "http://10.0.0.76:8096",
+      system: {},
+      plugins: [{ name: "" }],
     };
 
     // Act


### PR DESCRIPTION
## Summary

- Add plugin installation support via Jellyfin Package API
- Add plugin configuration support with arbitrary key-value pairs
- Refactor apply modules to use fluent `ChangeSetBuilder` pattern

## Changes

### New Features

**Plugin Installation**
- New `plugins` section in config with `name` field
- Installs plugins from configured repositories via `POST /Packages/Installed/{name}`
- Skips already-installed plugins (idempotent)

**Plugin Configuration**
- Optional `configuration` field accepts arbitrary key-value pairs
- Uses `GET/POST /Plugins/{pluginId}/Configuration` endpoints
- Only updates specified fields; preserves unspecified fields
- Re-fetches plugin list after installation so newly installed plugins can be configured

### Refactoring

**ChangeSetBuilder Pattern** (`src/lib/changeset.ts`)
- Fluent builder wrapping `json-diff-ts` operations
- `atomize()` / `unatomize()` for nested structure handling
- `withoutRemoves()` / `withoutUpdates()` / `withKey()` filters
- Applied across all apply modules: branding, encoding, library, system, users, plugins

### Files Changed (33 files, +2227/-1499 lines)

| Category | Files |
|----------|-------|
| API | `jellyfin.types.ts`, `jellyfin_client.ts` |
| Apply | `plugins.ts` (new), `branding-options.ts`, `encoding-options.ts`, `library.ts`, `system.ts`, `users.ts` |
| Types | `config/plugins.ts` (new), `schema/plugins.ts`, `config/root.ts` |
| Lib | `changeset.ts` (new) |
| Pipeline | `index.ts` |
| Tests | `plugins.spec.ts` (new), updates to existing test files |
| Docs | `README.md` |

## Test Plan

- [x] All 397 unit tests pass
- [x] TypeScript type check passes
- [x] ESLint passes
- [x] Integration test: plugin installation works
- [x] Integration test: plugin configuration updates correctly
- [x] Integration test: idempotent on second run

Closes https://github.com/venkyr77/jellarr/issues/40