### PR TITLE
Misc options for library and server configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,13 @@ users:
     policy:
       isAdministrator: true
       loginAttemptsBeforeLockout: 3
+      enabledLibraries:
+        - "Movies"
+        - "Shows"
 ```
+
+`policy.enabledLibraries` accepts library names; jellarr resolves them to folder
+IDs when talking to the Jellyfin API.
 
 **Password Security:**
 
@@ -517,6 +523,9 @@ users:
     policy:
       isAdministrator: true
       loginAttemptsBeforeLockout: 3
+      enabledLibraries:
+        - "Movies"
+        - "Shows"
 plugins:
   - name: "Trakt"
     configuration:

--- a/nix/module/types/library.nix
+++ b/nix/module/types/library.nix
@@ -12,11 +12,50 @@
     };
   };
 
+  typeOptionsConfigType = types.submodule {
+    options = {
+      type = mkOption {
+        type = types.str;
+        description = "Type name. E.g., 'Movie', 'Series', etc.";
+      };
+      metadataFetchers = mkOption {
+        type = types.listOf types.str;
+        description = "List of metadata fetchers to use for this type.";
+      };
+      metadataFetcherOrder = mkOption {
+        type = types.nullOr (types.listOf types.str);
+        description = "List defining the order of metadata fetchers for this type. Defaults to metadataFetchers if not set.";
+        default = null;
+      };
+      imageFetchers = mkOption {
+        type = types.listOf types.str;
+        description = "List of image fetchers to use for this type.";
+      };
+      imageFetcherOrder = mkOption {
+        type = types.nullOr (types.listOf types.str);
+        description = "List defining the order of image fetchers for this type. Defaults to imageFetchers if not set.";
+        default = null;
+      };
+    };
+  };
+
   libraryOptionsConfigType = types.submodule {
     options = {
       pathInfos = mkOption {
         type = types.listOf pathInfoConfigType;
         description = "List of paths for this library.";
+      };
+      typeOptions = mkOption {
+        type = types.listOf typeOptionsConfigType;
+        default = [];
+        example = [
+          {
+            type = "Movie";
+            metadataFetchers = ["TheMovieDB"];
+            imageFetchers = ["TheMovieDB"];
+          }
+        ];
+        description = "typeOptions config for this library.";
       };
     };
   };
@@ -65,11 +104,27 @@
         >= 1
         || throw "Library '${folder.name}' must have at least one path in pathInfos"; {
           inherit (folder) name collectionType;
-          libraryOptions = {
-            pathInfos =
-              map (pathInfo: {inherit (pathInfo) path;})
-              folder.libraryOptions.pathInfos;
-          };
+          libraryOptions =
+            {
+              pathInfos =
+                map (pathInfo: {inherit (pathInfo) path;})
+                folder.libraryOptions.pathInfos;
+            }
+            // optionalAttrs ((folder.libraryOptions.typeOptions or []) != []) {
+              typeOptions =
+                map (typeOpt: {
+                  inherit (typeOpt) type metadataFetchers imageFetchers;
+                  metadataFetcherOrder =
+                    if (typeOpt.metadataFetcherOrder or null) != null
+                    then typeOpt.metadataFetcherOrder
+                    else typeOpt.metadataFetchers;
+                  imageFetcherOrder =
+                    if (typeOpt.imageFetcherOrder or null) != null
+                    then typeOpt.imageFetcherOrder
+                    else typeOpt.imageFetchers;
+                })
+                (folder.libraryOptions.typeOptions or []);
+            };
         })
       cfg.virtualFolders;
     };

--- a/nix/module/types/library.nix
+++ b/nix/module/types/library.nix
@@ -45,6 +45,66 @@
         type = types.listOf pathInfoConfigType;
         description = "List of paths for this library.";
       };
+      automaticallyAddToCollection = mkOption {
+        type = nullOr types.bool;
+        default = null;
+        description = "Automatically add content to collections.";
+      };
+      enableChapterImageExtraction = mkOption {
+        type = nullOr types.bool;
+        default = null;
+        description = "Enable chapter image extraction.";
+      };
+      extractChapterImagesDuringLibraryScan = mkOption {
+        type = nullOr types.bool;
+        default = null;
+        description = "Extract chapter images during library scan.";
+      };
+      extractTrickplayImagesDuringLibraryScan = mkOption {
+        type = nullOr types.bool;
+        default = null;
+        description = "Extract trickplay images during library scan.";
+      };
+      enableEmbeddedEpisodeInfos = mkOption {
+        type = nullOr types.bool;
+        default = null;
+        description = "Enable embedded episode infos.";
+      };
+      enableEmbeddedExtraTitles = mkOption {
+        type = nullOr types.bool;
+        default = null;
+        description = "Enable embedded extra titles.";
+      };
+      enableTrickplayImageExtraction = mkOption {
+        type = nullOr types.bool;
+        default = null;
+        description = "Enable trickplay image extraction.";
+      };
+      saveTrickplayWithMedia = mkOption {
+        type = nullOr types.bool;
+        default = null;
+        description = "Save trickplay with media.";
+      };
+      metadataSavers = mkOption {
+        type = nullOr (types.listOf types.str);
+        default = null;
+        description = "List of metadata savers.";
+      };
+      saveLocalMetadata = mkOption {
+        type = nullOr types.bool;
+        default = null;
+        description = "Save local metadata.";
+      };
+      automaticRefreshIntervalDays = mkOption {
+        type = nullOr types.int;
+        default = null;
+        description = "Automatic refresh interval in days.";
+      };
+      enableRealtimeMonitor = mkOption {
+        type = nullOr types.bool;
+        default = null;
+        description = "Enable realtime monitor.";
+      };
       typeOptions = mkOption {
         type = types.listOf typeOptionsConfigType;
         default = [];
@@ -102,15 +162,53 @@
       virtualFolders = map (folder:
         assert (builtins.length folder.libraryOptions.pathInfos)
         >= 1
-        || throw "Library '${folder.name}' must have at least one path in pathInfos"; {
+        || throw "Library '${folder.name}' must have at least one path in pathInfos"; let
+          lo = folder.libraryOptions;
+        in {
           inherit (folder) name collectionType;
           libraryOptions =
             {
               pathInfos =
                 map (pathInfo: {inherit (pathInfo) path;})
-                folder.libraryOptions.pathInfos;
+                lo.pathInfos;
             }
-            // optionalAttrs ((folder.libraryOptions.typeOptions or []) != []) {
+            // optionalAttrs (lo ? automaticallyAddToCollection && lo.automaticallyAddToCollection != null) {
+              inherit (lo) automaticallyAddToCollection;
+            }
+            // optionalAttrs (lo ? enableChapterImageExtraction && lo.enableChapterImageExtraction != null) {
+              inherit (lo) enableChapterImageExtraction;
+            }
+            // optionalAttrs (lo ? extractChapterImagesDuringLibraryScan && lo.extractChapterImagesDuringLibraryScan != null) {
+              inherit (lo) extractChapterImagesDuringLibraryScan;
+            }
+            // optionalAttrs (lo ? extractTrickplayImagesDuringLibraryScan && lo.extractTrickplayImagesDuringLibraryScan != null) {
+              inherit (lo) extractTrickplayImagesDuringLibraryScan;
+            }
+            // optionalAttrs (lo ? enableEmbeddedEpisodeInfos && lo.enableEmbeddedEpisodeInfos != null) {
+              inherit (lo) enableEmbeddedEpisodeInfos;
+            }
+            // optionalAttrs (lo ? enableEmbeddedExtraTitles && lo.enableEmbeddedExtraTitles != null) {
+              inherit (lo) enableEmbeddedExtraTitles;
+            }
+            // optionalAttrs (lo ? enableTrickplayImageExtraction && lo.enableTrickplayImageExtraction != null) {
+              inherit (lo) enableTrickplayImageExtraction;
+            }
+            // optionalAttrs (lo ? saveTrickplayWithMedia && lo.saveTrickplayWithMedia != null) {
+              inherit (lo) saveTrickplayWithMedia;
+            }
+            // optionalAttrs (lo ? metadataSavers && lo.metadataSavers != null) {
+              inherit (lo) metadataSavers;
+            }
+            // optionalAttrs (lo ? saveLocalMetadata && lo.saveLocalMetadata != null) {
+              inherit (lo) saveLocalMetadata;
+            }
+            // optionalAttrs (lo ? automaticRefreshIntervalDays && lo.automaticRefreshIntervalDays != null) {
+              inherit (lo) automaticRefreshIntervalDays;
+            }
+            // optionalAttrs (lo ? enableRealtimeMonitor && lo.enableRealtimeMonitor != null) {
+              inherit (lo) enableRealtimeMonitor;
+            }
+            // optionalAttrs ((lo.typeOptions or []) != []) {
               typeOptions =
                 map (typeOpt: {
                   inherit (typeOpt) type metadataFetchers imageFetchers;

--- a/nix/module/types/system.nix
+++ b/nix/module/types/system.nix
@@ -32,6 +32,11 @@
         default = null;
         description = "Enable hardware encoding for trickplay.";
       };
+      processThreads = mkOption {
+        type = nullOr types.int;
+        default = null;
+        description = "Number of threads to use for trickplay processing.";
+      };
     };
   };
 
@@ -55,10 +60,16 @@
     };
   };
 
-  mkTrickplayOptionsConfig = cfg:
+  mkTrickplayOptionsConfig = cfg: let
+    c =
+      if cfg == null
+      then {}
+      else cfg;
+  in
     {}
-    // optionalAttrs (cfg.enableHwAcceleration != null) {inherit (cfg) enableHwAcceleration;}
-    // optionalAttrs (cfg.enableHwEncoding != null) {inherit (cfg) enableHwEncoding;};
+    // optionalAttrs (c ? enableHwAcceleration && c.enableHwAcceleration != null) {inherit (c) enableHwAcceleration;}
+    // optionalAttrs (c ? enableHwEncoding && c.enableHwEncoding != null) {inherit (c) enableHwEncoding;}
+    // optionalAttrs (c ? processThreads && c.processThreads != null) {inherit (c) processThreads;};
 
   mkSystemConfig = cfg:
     {}

--- a/nix/module/types/system.nix
+++ b/nix/module/types/system.nix
@@ -42,6 +42,11 @@
 
   systemConfigType = types.submodule {
     options = {
+      serverName = mkOption {
+        type = nullOr types.str;
+        default = null;
+        description = "Server name shown in clients.";
+      };
       enableMetrics = mkOption {
         type = nullOr types.bool;
         default = null;
@@ -71,18 +76,24 @@
     // optionalAttrs (c ? enableHwEncoding && c.enableHwEncoding != null) {inherit (c) enableHwEncoding;}
     // optionalAttrs (c ? processThreads && c.processThreads != null) {inherit (c) processThreads;};
 
-  mkSystemConfig = cfg:
+  mkSystemConfig = cfg: let
+    c =
+      if cfg == null
+      then {}
+      else cfg;
+  in
     {}
-    // optionalAttrs (cfg.enableMetrics != null) {inherit (cfg) enableMetrics;}
-    // optionalAttrs (cfg.pluginRepositories != null) {
+    // optionalAttrs (c ? serverName && c.serverName != null) {inherit (c) serverName;}
+    // optionalAttrs (c ? enableMetrics && c.enableMetrics != null) {inherit (c) enableMetrics;}
+    // optionalAttrs (c ? pluginRepositories && c.pluginRepositories != null) {
       pluginRepositories = map (repo:
         assert repo.name != "" || throw "Plugin repository name cannot be empty"; {
           inherit (repo) name url enabled;
         })
-      cfg.pluginRepositories;
+      c.pluginRepositories;
     }
-    // optionalAttrs (cfg.trickplayOptions != null) {
-      trickplayOptions = mkTrickplayOptionsConfig cfg.trickplayOptions;
+    // optionalAttrs (c ? trickplayOptions && c.trickplayOptions != null) {
+      trickplayOptions = mkTrickplayOptionsConfig c.trickplayOptions;
     };
 in {
   inherit systemConfigType mkSystemConfig;

--- a/nix/module/types/users.nix
+++ b/nix/module/types/users.nix
@@ -15,6 +15,16 @@
         default = null;
         description = "Number of login attempts before lockout (minimum 1).";
       };
+      enableAllFolders = mkOption {
+        type = nullOr types.bool;
+        default = null;
+        description = "Allow user to access all folders.";
+      };
+      enableCollectionManagement = mkOption {
+        type = nullOr types.bool;
+        default = null;
+        description = "Allow user to manage collections.";
+      };
     };
   };
 
@@ -44,14 +54,21 @@
 
   usersConfigType = nullOr (types.listOf userConfigType);
 
-  mkUserPolicyConfig = cfg:
+  mkUserPolicyConfig = cfg: let
+    c =
+      if cfg == null
+      then {}
+      else cfg;
+  in
     {}
-    // optionalAttrs (cfg.isAdministrator != null) {inherit (cfg) isAdministrator;}
-    // optionalAttrs (cfg.loginAttemptsBeforeLockout != null) (
-      assert cfg.loginAttemptsBeforeLockout
+    // optionalAttrs (c ? isAdministrator && c.isAdministrator != null) {inherit (c) isAdministrator;}
+    // optionalAttrs (c ? loginAttemptsBeforeLockout && c.loginAttemptsBeforeLockout != null) (
+      assert c.loginAttemptsBeforeLockout
       >= 1
-      || throw "loginAttemptsBeforeLockout must be at least 1"; {inherit (cfg) loginAttemptsBeforeLockout;}
-    );
+      || throw "loginAttemptsBeforeLockout must be at least 1"; {inherit (c) loginAttemptsBeforeLockout;}
+    )
+    // optionalAttrs (c ? enableAllFolders && c.enableAllFolders != null) {inherit (c) enableAllFolders;}
+    // optionalAttrs (c ? enableCollectionManagement && c.enableCollectionManagement != null) {inherit (c) enableCollectionManagement;};
 
   mkUsersConfig = cfg:
     map (user:

--- a/nix/module/types/users.nix
+++ b/nix/module/types/users.nix
@@ -30,6 +30,11 @@
         default = null;
         description = "Allow user to manage collections.";
       };
+      maxActiveSessions = mkOption {
+        type = nullOr types.int;
+        default = null;
+        description = "Maximum concurrent active sessions for the user.";
+      };
     };
   };
 
@@ -64,11 +69,6 @@
         default = null;
         description = "Subtitle language preference code.";
       };
-      maxActiveSessions = mkOption {
-        type = nullOr types.int;
-        default = null;
-        description = "Maximum concurrent active sessions for the user.";
-      };
     };
   };
 
@@ -91,22 +91,24 @@
       assert lib.all (library: library != "" || throw "enabledLibraries entries cannot be empty") c.enabledLibraries; {inherit (c) enabledLibraries;}
     )
     // optionalAttrs (c ? enableAllFolders && c.enableAllFolders != null) {inherit (c) enableAllFolders;}
-    // optionalAttrs (c ? enableCollectionManagement && c.enableCollectionManagement != null) {inherit (c) enableCollectionManagement;};
+    // optionalAttrs (c ? enableCollectionManagement && c.enableCollectionManagement != null) {inherit (c) enableCollectionManagement;}
+    // optionalAttrs (c ? maxActiveSessions && c.maxActiveSessions != null) {inherit (c) maxActiveSessions;};
 
   mkUsersConfig = cfg:
-    map (user:
-      assert user.name != "" || throw "User name cannot be empty";
-      assert (user.password != null)
-      != (user.passwordFile != null)
-      || throw "User '${user.name}' must specify exactly one of 'password' or 'passwordFile'";
-        {}
-        // {inherit (user) name;}
-        // optionalAttrs (user.password != null) {inherit (user) password;}
-        // optionalAttrs (user.passwordFile != null) {inherit (user) passwordFile;}
-        // optionalAttrs (user.policy != null) {policy = mkUserPolicyConfig user.policy;}
-        // optionalAttrs (user ? displayMissingEpisodes && user.displayMissingEpisodes != null) {inherit (user) displayMissingEpisodes;}
-        // optionalAttrs (user ? subtitleLanguagePreference && user.subtitleLanguagePreference != null) {inherit (user) subtitleLanguagePreference;}
-        // optionalAttrs (user ? maxActiveSessions && user.maxActiveSessions != null) {inherit (user) maxActiveSessions;})
+    map (
+      user:
+        assert user.name != "" || throw "User name cannot be empty";
+        assert (user.password != null)
+        != (user.passwordFile != null)
+        || throw "User '${user.name}' must specify exactly one of 'password' or 'passwordFile'";
+          {}
+          // {inherit (user) name;}
+          // optionalAttrs (user.password != null) {inherit (user) password;}
+          // optionalAttrs (user.passwordFile != null) {inherit (user) passwordFile;}
+          // optionalAttrs (user.policy != null) {policy = mkUserPolicyConfig user.policy;}
+          // optionalAttrs (user ? displayMissingEpisodes && user.displayMissingEpisodes != null) {inherit (user) displayMissingEpisodes;}
+          // optionalAttrs (user ? subtitleLanguagePreference && user.subtitleLanguagePreference != null) {inherit (user) subtitleLanguagePreference;}
+    )
     cfg;
 in {
   inherit usersConfigType mkUsersConfig;

--- a/nix/module/types/users.nix
+++ b/nix/module/types/users.nix
@@ -59,6 +59,11 @@
         default = null;
         description = "Subtitle language preference code.";
       };
+      maxActiveSessions = mkOption {
+        type = nullOr types.int;
+        default = null;
+        description = "Maximum concurrent active sessions for the user.";
+      };
     };
   };
 
@@ -92,7 +97,8 @@
         // optionalAttrs (user.passwordFile != null) {inherit (user) passwordFile;}
         // optionalAttrs (user.policy != null) {policy = mkUserPolicyConfig user.policy;}
         // optionalAttrs (user ? displayMissingEpisodes && user.displayMissingEpisodes != null) {inherit (user) displayMissingEpisodes;}
-        // optionalAttrs (user ? subtitleLanguagePreference && user.subtitleLanguagePreference != null) {inherit (user) subtitleLanguagePreference;})
+        // optionalAttrs (user ? subtitleLanguagePreference && user.subtitleLanguagePreference != null) {inherit (user) subtitleLanguagePreference;}
+        // optionalAttrs (user ? maxActiveSessions && user.maxActiveSessions != null) {inherit (user) maxActiveSessions;})
     cfg;
 in {
   inherit usersConfigType mkUsersConfig;

--- a/nix/module/types/users.nix
+++ b/nix/module/types/users.nix
@@ -49,6 +49,16 @@
         default = null;
         description = "User policy configuration.";
       };
+      displayMissingEpisodes = mkOption {
+        type = nullOr types.bool;
+        default = null;
+        description = "Show missing episodes for the user.";
+      };
+      subtitleLanguagePreference = mkOption {
+        type = nullOr types.str;
+        default = null;
+        description = "Subtitle language preference code.";
+      };
     };
   };
 
@@ -80,7 +90,9 @@
         // {inherit (user) name;}
         // optionalAttrs (user.password != null) {inherit (user) password;}
         // optionalAttrs (user.passwordFile != null) {inherit (user) passwordFile;}
-        // optionalAttrs (user.policy != null) {policy = mkUserPolicyConfig user.policy;})
+        // optionalAttrs (user.policy != null) {policy = mkUserPolicyConfig user.policy;}
+        // optionalAttrs (user ? displayMissingEpisodes && user.displayMissingEpisodes != null) {inherit (user) displayMissingEpisodes;}
+        // optionalAttrs (user ? subtitleLanguagePreference && user.subtitleLanguagePreference != null) {inherit (user) subtitleLanguagePreference;})
     cfg;
 in {
   inherit usersConfigType mkUsersConfig;

--- a/nix/module/types/users.nix
+++ b/nix/module/types/users.nix
@@ -15,6 +15,11 @@
         default = null;
         description = "Number of login attempts before lockout (minimum 1).";
       };
+      enabledLibraries = mkOption {
+        type = nullOr (types.listOf types.str);
+        default = null;
+        description = "List of library names the user can access.";
+      };
       enableAllFolders = mkOption {
         type = nullOr types.bool;
         default = null;
@@ -81,6 +86,9 @@
       assert c.loginAttemptsBeforeLockout
       >= 1
       || throw "loginAttemptsBeforeLockout must be at least 1"; {inherit (c) loginAttemptsBeforeLockout;}
+    )
+    // optionalAttrs (c ? enabledLibraries && c.enabledLibraries != null) (
+      assert lib.all (library: library != "" || throw "enabledLibraries entries cannot be empty") c.enabledLibraries; {inherit (c) enabledLibraries;}
     )
     // optionalAttrs (c ? enableAllFolders && c.enableAllFolders != null) {inherit (c) enableAllFolders;}
     // optionalAttrs (c ? enableCollectionManagement && c.enableCollectionManagement != null) {inherit (c) enableCollectionManagement;};

--- a/nix/tests/module/types/library.nix
+++ b/nix/tests/module/types/library.nix
@@ -227,6 +227,84 @@ in [
       ];
     })
 
+  (assertEq "typeOptions are mapped when provided" (mkLibraryConfig {
+      virtualFolders = [
+        {
+          name = "Movies";
+          collectionType = "movies";
+          libraryOptions = {
+            pathInfos = [{path = "/data/movies";}];
+            typeOptions = [
+              {
+                type = "Movie";
+                metadataFetchers = ["TheMovieDB"];
+                imageFetchers = ["TheMovieDB"];
+              }
+            ];
+          };
+        }
+      ];
+    }) {
+      virtualFolders = [
+        {
+          name = "Movies";
+          collectionType = "movies";
+          libraryOptions = {
+            pathInfos = [{path = "/data/movies";}];
+            typeOptions = [
+              {
+                type = "Movie";
+                metadataFetchers = ["TheMovieDB"];
+                metadataFetcherOrder = ["TheMovieDB"];
+                imageFetchers = ["TheMovieDB"];
+                imageFetcherOrder = ["TheMovieDB"];
+              }
+            ];
+          };
+        }
+      ];
+    })
+
+  (assertEq "typeOptions orders fallback when null" (mkLibraryConfig {
+      virtualFolders = [
+        {
+          name = "Movies";
+          collectionType = "movies";
+          libraryOptions = {
+            pathInfos = [{path = "/data/movies";}];
+            typeOptions = [
+              {
+                type = "Movie";
+                metadataFetchers = ["TheMovieDB"];
+                metadataFetcherOrder = null;
+                imageFetchers = ["TheMovieDB"];
+                imageFetcherOrder = null;
+              }
+            ];
+          };
+        }
+      ];
+    }) {
+      virtualFolders = [
+        {
+          name = "Movies";
+          collectionType = "movies";
+          libraryOptions = {
+            pathInfos = [{path = "/data/movies";}];
+            typeOptions = [
+              {
+                type = "Movie";
+                metadataFetchers = ["TheMovieDB"];
+                metadataFetcherOrder = ["TheMovieDB"];
+                imageFetchers = ["TheMovieDB"];
+                imageFetcherOrder = ["TheMovieDB"];
+              }
+            ];
+          };
+        }
+      ];
+    })
+
   (assertEq "empty virtualFolders array" (mkLibraryConfig {virtualFolders = [];}) {virtualFolders = [];})
 
   (assertThrows "reject empty pathInfos" (mkLibraryConfig {

--- a/nix/tests/module/types/library.nix
+++ b/nix/tests/module/types/library.nix
@@ -241,6 +241,18 @@ in [
                 imageFetchers = ["TheMovieDB"];
               }
             ];
+            automaticallyAddToCollection = true;
+            enableChapterImageExtraction = true;
+            extractChapterImagesDuringLibraryScan = true;
+            extractTrickplayImagesDuringLibraryScan = true;
+            enableEmbeddedEpisodeInfos = true;
+            enableEmbeddedExtraTitles = true;
+            enableTrickplayImageExtraction = true;
+            saveTrickplayWithMedia = true;
+            metadataSavers = ["Nfo"];
+            saveLocalMetadata = true;
+            automaticRefreshIntervalDays = 14;
+            enableRealtimeMonitor = true;
           };
         }
       ];
@@ -260,6 +272,18 @@ in [
                 imageFetcherOrder = ["TheMovieDB"];
               }
             ];
+            automaticallyAddToCollection = true;
+            enableChapterImageExtraction = true;
+            extractChapterImagesDuringLibraryScan = true;
+            extractTrickplayImagesDuringLibraryScan = true;
+            enableEmbeddedEpisodeInfos = true;
+            enableEmbeddedExtraTitles = true;
+            enableTrickplayImageExtraction = true;
+            saveTrickplayWithMedia = true;
+            metadataSavers = ["Nfo"];
+            saveLocalMetadata = true;
+            automaticRefreshIntervalDays = 14;
+            enableRealtimeMonitor = true;
           };
         }
       ];

--- a/nix/tests/module/types/system.nix
+++ b/nix/tests/module/types/system.nix
@@ -35,6 +35,7 @@ in [
       trickplayOptions = {
         enableHwAcceleration = true;
         enableHwEncoding = false;
+        processThreads = 2;
       };
     }) {
       enableMetrics = true;
@@ -48,6 +49,7 @@ in [
       trickplayOptions = {
         enableHwAcceleration = true;
         enableHwEncoding = false;
+        processThreads = 2;
       };
     })
 
@@ -151,5 +153,16 @@ in [
       enableHwAcceleration = false;
       enableHwEncoding = true;
     };
+  })
+
+  (assertEq "trickplay processThreads only" (mkSystemConfig (nullConfig
+    // {
+      trickplayOptions = {
+        enableHwAcceleration = null;
+        enableHwEncoding = null;
+        processThreads = 3;
+      };
+    })) {
+    trickplayOptions = {processThreads = 3;};
   })
 ]

--- a/nix/tests/module/types/system.nix
+++ b/nix/tests/module/types/system.nix
@@ -8,12 +8,17 @@
   inherit (types.system) mkSystemConfig;
 
   nullConfig = {
+    serverName = null;
     enableMetrics = null;
     pluginRepositories = null;
     trickplayOptions = null;
   };
 in [
   (assertEq "empty config" (mkSystemConfig nullConfig) {})
+
+  (assertEq "serverName only" (mkSystemConfig (nullConfig // {serverName = "MyServer";})) {
+    serverName = "MyServer";
+  })
 
   (assertEq "enableMetrics true" (mkSystemConfig (nullConfig // {enableMetrics = true;})) {
     enableMetrics = true;

--- a/nix/tests/module/types/users.nix
+++ b/nix/tests/module/types/users.nix
@@ -153,6 +153,23 @@ in [
       }
     ])
 
+  (assertEq "policy maxActiveSessions only" (mkUsersConfig [
+      {
+        name = "user";
+        password = "pass";
+        passwordFile = null;
+        policy = {
+          maxActiveSessions = 2;
+        };
+      }
+    ]) [
+      {
+        name = "user";
+        password = "pass";
+        policy = {maxActiveSessions = 2;};
+      }
+    ])
+
   (assertEq "empty policy" (mkUsersConfig [
       {
         name = "user";

--- a/nix/tests/module/types/users.nix
+++ b/nix/tests/module/types/users.nix
@@ -170,6 +170,72 @@ in [
       }
     ])
 
+  (assertEq "policy enableAllFolders only" (mkUsersConfig [
+      {
+        name = "user";
+        password = "pass";
+        passwordFile = null;
+        policy = {
+          enableAllFolders = true;
+        };
+      }
+    ]) [
+      {
+        name = "user";
+        password = "pass";
+        policy = {enableAllFolders = true;};
+      }
+    ])
+
+  (assertEq "policy enableCollectionManagement only" (mkUsersConfig [
+      {
+        name = "user";
+        password = "pass";
+        passwordFile = null;
+        policy = {
+          enableCollectionManagement = true;
+        };
+      }
+    ]) [
+      {
+        name = "user";
+        password = "pass";
+        policy = {enableCollectionManagement = true;};
+      }
+    ])
+
+  (assertEq "displayMissingEpisodes only" (mkUsersConfig [
+      {
+        name = "user";
+        password = "pass";
+        passwordFile = null;
+        policy = null;
+        displayMissingEpisodes = true;
+      }
+    ]) [
+      {
+        name = "user";
+        password = "pass";
+        displayMissingEpisodes = true;
+      }
+    ])
+
+  (assertEq "subtitleLanguagePreference only" (mkUsersConfig [
+      {
+        name = "user";
+        password = "pass";
+        passwordFile = null;
+        policy = null;
+        subtitleLanguagePreference = "eng";
+      }
+    ]) [
+      {
+        name = "user";
+        password = "pass";
+        subtitleLanguagePreference = "eng";
+      }
+    ])
+
   (assertEq "empty policy" (mkUsersConfig [
       {
         name = "user";

--- a/nix/tests/module/types/users.nix
+++ b/nix/tests/module/types/users.nix
@@ -213,6 +213,25 @@ in [
       }
     ])
 
+  (assertEq "policy with enabledLibraries" (mkUsersConfig [
+      {
+        name = "user";
+        password = "pass";
+        passwordFile = null;
+        policy = {
+          enabledLibraries = ["Movies" "Shows"];
+        };
+      }
+    ]) [
+      {
+        name = "user";
+        password = "pass";
+        policy = {
+          enabledLibraries = ["Movies" "Shows"];
+        };
+      }
+    ])
+
   (assertEq "list with users having policies" (mkUsersConfig [
       {
         name = "admin";
@@ -247,6 +266,17 @@ in [
         };
       }
     ])
+
+  (assertThrows "reject empty enabledLibraries entry" (mkUsersConfig [
+    {
+      name = "user";
+      password = "pass";
+      passwordFile = null;
+      policy = {
+        enabledLibraries = [""];
+      };
+    }
+  ]))
 
   (assertThrows "reject list with invalid policy" (mkUsersConfig [
     {

--- a/src/api/jellyfin.types.ts
+++ b/src/api/jellyfin.types.ts
@@ -11,6 +11,7 @@ import type {
   UserDtoSchema,
   CreateUserByNameSchema,
   UserPolicySchema,
+  UserConfigurationSchema,
 } from "../types/schema/users";
 import {
   type PluginInfoSchema,
@@ -68,6 +69,10 @@ export interface JellyfinClient {
   getUsers(): Promise<UserDtoSchema[]>;
   createUser(body: CreateUserByNameSchema): Promise<void>;
   updateUserPolicy(userId: string, body: UserPolicySchema): Promise<void>;
+  updateUserConfiguration(
+    userId: string,
+    body: UserConfigurationSchema,
+  ): Promise<void>;
   completeStartupWizard(): Promise<void>;
   getPlugins(): Promise<PluginInfoSchema[]>;
   installPackage(name: string): Promise<void>;

--- a/src/api/jellyfin.types.ts
+++ b/src/api/jellyfin.types.ts
@@ -4,6 +4,7 @@ import type {
   VirtualFolderInfoSchema,
   AddVirtualFolderDtoSchema,
   CollectionTypeSchema,
+  UpdateLibraryOptionsDtoSchema,
 } from "../types/schema/library";
 import type { BrandingOptionsDtoSchema } from "../types/schema/branding-options";
 import type {
@@ -55,6 +56,10 @@ export interface JellyfinClient {
     name: string,
     collectionType: CollectionTypeSchema | undefined,
     body: AddVirtualFolderDtoSchema,
+  ): Promise<void>;
+  updateLibraryOptions(
+    libraryId: string,
+    body: UpdateLibraryOptionsDtoSchema,
   ): Promise<void>;
   getBrandingConfiguration(): Promise<BrandingOptionsDtoSchema>;
   updateBrandingConfiguration(

--- a/src/api/jellyfin_client.ts
+++ b/src/api/jellyfin_client.ts
@@ -252,6 +252,23 @@ export function createJellyfinClient(
       }
     },
 
+    async updateUserConfiguration(
+      userId: string,
+      body: UserConfigurationSchema,
+    ): Promise<void> {
+      const res = await client.POST("/Users/{userId}/Configuration", {
+        params: { path: { userId } },
+        body,
+        headers: { "content-type": "application/json" },
+      });
+
+      if (res.error) {
+        throw new Error(
+          `POST /Users/{userId}/Configuration failed: ${res.response.status.toString()}`,
+        );
+      }
+    },
+
     async completeStartupWizard(): Promise<void> {
       const res: PostStartupCompleteResponse =
         await client.POST("/Startup/Complete");

--- a/src/api/jellyfin_client.ts
+++ b/src/api/jellyfin_client.ts
@@ -4,6 +4,7 @@ import type {
   VirtualFolderInfoSchema,
   AddVirtualFolderDtoSchema,
   CollectionTypeSchema,
+  UpdateLibraryOptionsDtoSchema,
 } from "../types/schema/library";
 import type { BrandingOptionsDtoSchema } from "../types/schema/branding-options";
 import type {
@@ -150,6 +151,23 @@ export function createJellyfinClient(
       if (res.error) {
         throw new Error(
           `POST /Library/VirtualFolders failed: ${res.response.status.toString()}`,
+        );
+      }
+    },
+
+    async updateLibraryOptions(
+      libraryId: string,
+      body: UpdateLibraryOptionsDtoSchema,
+    ): Promise<void> {
+      const res = await client.POST("/Library/VirtualFolders/LibraryOptions", {
+        params: { query: { libraryId } },
+        body,
+        headers: { "content-type": "application/json" },
+      });
+
+      if (res.error) {
+        throw new Error(
+          `POST /Library/VirtualFolders/LibraryOptions failed: ${res.response.status.toString()}`,
         );
       }
     },

--- a/src/apply/library.ts
+++ b/src/apply/library.ts
@@ -13,7 +13,7 @@ import {
   mapVirtualFolderConfigToSchema,
   mapVirtualFolderInfoSchemaToAddVirtualFolderDtoSchema,
 } from "../mappers/library";
-import { diff, type IChange } from "json-diff-ts";
+import { applyChangeset, diff, Operation, type IChange } from "json-diff-ts";
 
 export type LibraryDiff = {
   toCreate?: VirtualFolderInfoSchema[];
@@ -23,6 +23,40 @@ export type LibraryDiff = {
     libraryOptions: LibraryOptionsSchema;
   }[];
 };
+
+type ChangeWithValue = IChange & {
+  embeddedKey?: string | number;
+  value?: unknown;
+};
+
+function resolveFolderId(
+  folder: VirtualFolderInfoSchema | undefined,
+): string | undefined {
+  if (!folder) return undefined;
+  return (
+    (folder as { Id?: string }).Id ??
+    (folder as { ItemId?: string | null }).ItemId ??
+    undefined
+  );
+}
+
+function resolveChangeName(change: ChangeWithValue): string | undefined {
+  const key: string = change.key;
+  if (key !== "" && Number.isNaN(Number(key))) return key;
+  const embeddedKey: string | number | undefined = change.embeddedKey;
+  if (
+    typeof embeddedKey === "string" &&
+    embeddedKey !== "" &&
+    Number.isNaN(Number(embeddedKey))
+  ) {
+    return embeddedKey;
+  }
+  const value: unknown = change.value;
+  if (value && typeof value === "object" && "Name" in value) {
+    return (value as { Name?: string }).Name;
+  }
+  return undefined;
+}
 
 export function calculateLibraryDiff(
   current: VirtualFolderInfoSchema[],
@@ -36,47 +70,6 @@ export function calculateLibraryDiff(
     mapVirtualFolderConfigToSchema,
   );
 
-  const toCreate: VirtualFolderInfoSchema[] = [];
-  const toUpdate: NonNullable<LibraryDiff["toUpdate"]> = [];
-
-  for (const folder of next) {
-    const existing: VirtualFolderInfoSchema | undefined = current.find(
-      (currentFolder: VirtualFolderInfoSchema) =>
-        currentFolder.Name === folder.Name,
-    );
-
-    if (!existing) {
-      toCreate.push(folder);
-      continue;
-    }
-
-    const currentOptions: LibraryOptionsSchema | undefined =
-      existing.LibraryOptions as LibraryOptionsSchema | undefined;
-    const nextOptions: LibraryOptionsSchema | undefined =
-      folder.LibraryOptions as LibraryOptionsSchema | undefined;
-
-    if (
-      currentOptions &&
-      nextOptions &&
-      JSON.stringify(currentOptions) === JSON.stringify(nextOptions)
-    ) {
-      continue;
-    }
-
-    const existingId: string | undefined =
-      (existing as { Id?: string }).Id ??
-      (existing as { ItemId?: string | null }).ItemId ??
-      undefined;
-
-    if (existingId && nextOptions) {
-      toUpdate.push({
-        id: existingId,
-        name: existing.Name ?? "",
-        libraryOptions: nextOptions,
-      });
-    }
-  }
-
   const changeSet: IChange[] = new ChangeSetBuilder(
     diff(current, next, {
       embeddedObjKeys: { ".": "Name" },
@@ -85,17 +78,82 @@ export function calculateLibraryDiff(
   )
     .atomize()
     .withoutRemoves()
-    .withoutUpdates()
     .toArray();
 
-  if (changeSet.length > 0) {
-    logger.info(JSON.stringify(changeSet));
+  if (changeSet.length === 0) return undefined;
+
+  logger.info(JSON.stringify(changeSet));
+
+  const addChanges: IChange[] = changeSet.filter(
+    (change: IChange) => change.type === Operation.ADD,
+  );
+  const updateChanges: ChangeWithValue[] = changeSet.filter(
+    (change: IChange) => change.type === Operation.UPDATE,
+  ) as ChangeWithValue[];
+
+  const toCreate: VirtualFolderInfoSchema[] | undefined =
+    addChanges.length > 0
+      ? (applyChangeset([], addChanges) as VirtualFolderInfoSchema[])
+      : undefined;
+
+  const currentByName: Map<string, VirtualFolderInfoSchema> = new Map(
+    current
+      .map((folder: VirtualFolderInfoSchema) =>
+        folder.Name ? [folder.Name, folder] : undefined,
+      )
+      .filter(
+        (
+          entry:
+            | [string, VirtualFolderInfoSchema]
+            | undefined
+            | [string, VirtualFolderInfoSchema | undefined],
+        ): entry is [string, VirtualFolderInfoSchema] => Array.isArray(entry),
+      ),
+  );
+  const nextByName: Map<string, VirtualFolderInfoSchema> = new Map(
+    next
+      .map((folder: VirtualFolderInfoSchema) =>
+        folder.Name ? [folder.Name, folder] : undefined,
+      )
+      .filter(
+        (
+          entry:
+            | [string, VirtualFolderInfoSchema]
+            | undefined
+            | [string, VirtualFolderInfoSchema | undefined],
+        ): entry is [string, VirtualFolderInfoSchema] => Array.isArray(entry),
+      ),
+  );
+
+  const toUpdate: NonNullable<LibraryDiff["toUpdate"]> = [];
+  const seenUpdate: Set<string> = new Set();
+
+  for (const change of updateChanges) {
+    const name: string | undefined = resolveChangeName(change);
+    if (!name || seenUpdate.has(name)) continue;
+
+    const currentFolder: VirtualFolderInfoSchema | undefined =
+      currentByName.get(name);
+    const desiredFolder: VirtualFolderInfoSchema | undefined =
+      nextByName.get(name);
+    const existingId: string | undefined = resolveFolderId(currentFolder);
+    const libraryOptions: LibraryOptionsSchema | undefined =
+      desiredFolder?.LibraryOptions as LibraryOptionsSchema | undefined;
+
+    if (!existingId || !libraryOptions) continue;
+
+    seenUpdate.add(name);
+    toUpdate.push({
+      id: existingId,
+      name,
+      libraryOptions,
+    });
   }
 
-  if (toCreate.length === 0 && toUpdate.length === 0) return undefined;
+  if (!toCreate && toUpdate.length === 0) return undefined;
 
   return {
-    toCreate: toCreate.length > 0 ? toCreate : undefined,
+    toCreate,
     toUpdate: toUpdate.length > 0 ? toUpdate : undefined,
   };
 }

--- a/src/apply/library.ts
+++ b/src/apply/library.ts
@@ -6,17 +6,28 @@ import type {
   VirtualFolderInfoSchema,
   CollectionTypeSchema,
   AddVirtualFolderDtoSchema,
+  UpdateLibraryOptionsDtoSchema,
+  LibraryOptionsSchema,
 } from "../types/schema/library";
 import {
   mapVirtualFolderConfigToSchema,
   mapVirtualFolderInfoSchemaToAddVirtualFolderDtoSchema,
 } from "../mappers/library";
-import { applyChangeset, diff, type IChange } from "json-diff-ts";
+import { diff, type IChange } from "json-diff-ts";
+
+export type LibraryDiff = {
+  toCreate?: VirtualFolderInfoSchema[];
+  toUpdate?: {
+    id: string;
+    name: string;
+    libraryOptions: LibraryOptionsSchema;
+  }[];
+};
 
 export function calculateLibraryDiff(
   current: VirtualFolderInfoSchema[],
   desired: VirtualFolderConfig[],
-): VirtualFolderInfoSchema[] | undefined {
+): LibraryDiff | undefined {
   if (desired.length === 0) {
     return undefined;
   }
@@ -25,7 +36,48 @@ export function calculateLibraryDiff(
     mapVirtualFolderConfigToSchema,
   );
 
-  const patch: IChange[] = new ChangeSetBuilder(
+  const toCreate: VirtualFolderInfoSchema[] = [];
+  const toUpdate: NonNullable<LibraryDiff["toUpdate"]> = [];
+
+  for (const folder of next) {
+    const existing: VirtualFolderInfoSchema | undefined = current.find(
+      (currentFolder: VirtualFolderInfoSchema) =>
+        currentFolder.Name === folder.Name,
+    );
+
+    if (!existing) {
+      toCreate.push(folder);
+      continue;
+    }
+
+    const currentOptions: LibraryOptionsSchema | undefined =
+      existing.LibraryOptions as LibraryOptionsSchema | undefined;
+    const nextOptions: LibraryOptionsSchema | undefined =
+      folder.LibraryOptions as LibraryOptionsSchema | undefined;
+
+    if (
+      currentOptions &&
+      nextOptions &&
+      JSON.stringify(currentOptions) === JSON.stringify(nextOptions)
+    ) {
+      continue;
+    }
+
+    const existingId: string | undefined =
+      (existing as { Id?: string }).Id ??
+      (existing as { ItemId?: string | null }).ItemId ??
+      undefined;
+
+    if (existingId && nextOptions) {
+      toUpdate.push({
+        id: existingId,
+        name: existing.Name ?? "",
+        libraryOptions: nextOptions,
+      });
+    }
+  }
+
+  const changeSet: IChange[] = new ChangeSetBuilder(
     diff(current, next, {
       embeddedObjKeys: { ".": "Name" },
       treatTypeChangeAsReplace: false,
@@ -36,33 +88,60 @@ export function calculateLibraryDiff(
     .withoutUpdates()
     .toArray();
 
-  if (patch.length !== 0) {
-    logger.info(JSON.stringify(patch));
-    return applyChangeset([], patch) as VirtualFolderInfoSchema[];
+  if (changeSet.length > 0) {
+    logger.info(JSON.stringify(changeSet));
   }
 
-  return undefined;
+  if (toCreate.length === 0 && toUpdate.length === 0) return undefined;
+
+  return {
+    toCreate: toCreate.length > 0 ? toCreate : undefined,
+    toUpdate: toUpdate.length > 0 ? toUpdate : undefined,
+  };
 }
 
 export async function applyLibrary(
   client: JellyfinClient,
-  virtualFoldersToAdd: VirtualFolderInfoSchema[] | undefined,
+  diffResult: LibraryDiff | undefined,
 ): Promise<void> {
-  if (!virtualFoldersToAdd) return;
+  if (!diffResult) return;
 
-  for (const virtualFolder of virtualFoldersToAdd) {
-    const name: string = virtualFolder.Name as string;
+  const { toCreate, toUpdate } = diffResult;
 
-    const collectionType: CollectionTypeSchema =
-      virtualFolder.CollectionType as CollectionTypeSchema;
+  if (!toCreate && !toUpdate) return;
 
-    logger.info(`Creating virtual folder: ${name}`);
+  if (toCreate) {
+    for (const virtualFolder of toCreate) {
+      if (!virtualFolder.Name) {
+        logger.warn("Skipping virtual folder without a Name");
+        continue;
+      }
 
-    const addVirtualFolderDto: AddVirtualFolderDtoSchema =
-      mapVirtualFolderInfoSchemaToAddVirtualFolderDtoSchema(virtualFolder);
+      const name: string = virtualFolder.Name as string;
+      const collectionType: CollectionTypeSchema =
+        virtualFolder.CollectionType as CollectionTypeSchema;
 
-    await client.addVirtualFolder(name, collectionType, addVirtualFolderDto);
+      logger.info(`Creating virtual folder: ${name}`);
 
-    logger.info(`✓ Created virtual folder: ${name} (${collectionType})`);
+      const addVirtualFolderDto: AddVirtualFolderDtoSchema =
+        mapVirtualFolderInfoSchemaToAddVirtualFolderDtoSchema(virtualFolder);
+
+      await client.addVirtualFolder(name, collectionType, addVirtualFolderDto);
+
+      logger.info(`✓ Created virtual folder: ${name} (${collectionType})`);
+    }
+  }
+
+  if (toUpdate) {
+    for (const update of toUpdate) {
+      const payload: UpdateLibraryOptionsDtoSchema = {
+        Id: update.id,
+        LibraryOptions: update.libraryOptions,
+      };
+
+      logger.info(`Updating library options: ${update.name}`);
+      await client.updateLibraryOptions(update.id, payload);
+      logger.info(`✓ Updated library options: ${update.name}`);
+    }
   }
 }

--- a/src/apply/library.ts
+++ b/src/apply/library.ts
@@ -70,6 +70,42 @@ export function calculateLibraryDiff(
     mapVirtualFolderConfigToSchema,
   );
 
+  const currentByName: Map<string, VirtualFolderInfoSchema> = new Map(
+    current
+      .map((folder: VirtualFolderInfoSchema) =>
+        folder.Name ? [folder.Name, folder] : undefined,
+      )
+      .filter(
+        (
+          entry:
+            | [string, VirtualFolderInfoSchema]
+            | undefined
+            | [string, VirtualFolderInfoSchema | undefined],
+        ): entry is [string, VirtualFolderInfoSchema] => Array.isArray(entry),
+      ),
+  );
+
+  for (const folder of next) {
+    const name: string | undefined = folder.Name ?? undefined;
+    if (!name) continue;
+    const currentFolder: VirtualFolderInfoSchema | undefined =
+      currentByName.get(name);
+    const currentType: string | undefined =
+      (currentFolder?.CollectionType as string | undefined) ?? undefined;
+    const desiredType: string | undefined =
+      (folder.CollectionType as string | undefined) ?? undefined;
+    if (
+      currentFolder &&
+      typeof currentType !== "undefined" &&
+      typeof desiredType !== "undefined" &&
+      currentType !== desiredType
+    ) {
+      throw new Error(
+        `Library '${name}' collectionType change is not supported (current: ${currentType}, desired: ${desiredType})`,
+      );
+    }
+  }
+
   const changeSet: IChange[] = new ChangeSetBuilder(
     diff(current, next, {
       embeddedObjKeys: { ".": "Name" },
@@ -96,20 +132,6 @@ export function calculateLibraryDiff(
       ? (applyChangeset([], addChanges) as VirtualFolderInfoSchema[])
       : undefined;
 
-  const currentByName: Map<string, VirtualFolderInfoSchema> = new Map(
-    current
-      .map((folder: VirtualFolderInfoSchema) =>
-        folder.Name ? [folder.Name, folder] : undefined,
-      )
-      .filter(
-        (
-          entry:
-            | [string, VirtualFolderInfoSchema]
-            | undefined
-            | [string, VirtualFolderInfoSchema | undefined],
-        ): entry is [string, VirtualFolderInfoSchema] => Array.isArray(entry),
-      ),
-  );
   const nextByName: Map<string, VirtualFolderInfoSchema> = new Map(
     next
       .map((folder: VirtualFolderInfoSchema) =>

--- a/src/apply/system.ts
+++ b/src/apply/system.ts
@@ -17,6 +17,14 @@ export function calculateSystemDiff(
     ...new ChangeSetBuilder(
       diff(current, next, { treatTypeChangeAsReplace: false }),
     )
+      .withKey("ServerName")
+      .withoutRemoves()
+      .atomize()
+      .toArray(),
+
+    ...new ChangeSetBuilder(
+      diff(current, next, { treatTypeChangeAsReplace: false }),
+    )
       .withKey("EnableMetrics")
       .withoutRemoves()
       .atomize()

--- a/src/apply/users.ts
+++ b/src/apply/users.ts
@@ -120,15 +120,24 @@ export function calculateUserPoliciesDiff(
       (curr: UserDtoSchema) => curr.Name === userConfig.name,
     );
 
-    if (
-      currentUserDtoSchema?.Id &&
-      currentUserDtoSchema.Policy &&
-      userConfig.policy
-    ) {
+    const hasPolicyUpdates: boolean =
+      typeof userConfig.policy !== "undefined" ||
+      typeof userConfig.maxActiveSessions !== "undefined";
+
+    if (currentUserDtoSchema?.Id && hasPolicyUpdates) {
+      const currentPolicy: UserPolicySchema =
+        (currentUserDtoSchema.Policy as UserPolicySchema) ?? {};
+      const desiredPolicy: UserPolicyConfig = {
+        ...(userConfig.policy ?? {}),
+        ...(typeof userConfig.maxActiveSessions !== "undefined"
+          ? { maxActiveSessions: userConfig.maxActiveSessions }
+          : {}),
+      };
+
       const userPolicyDiff: UserPolicySchema | undefined =
         calculateUserPolicyDiff(
-          currentUserDtoSchema.Policy,
-          userConfig.policy,
+          currentPolicy,
+          desiredPolicy,
           folderNameToIdMap,
         );
 

--- a/src/apply/users.ts
+++ b/src/apply/users.ts
@@ -106,15 +106,6 @@ export function calculateUserPoliciesDiff(
         ? new Map()
         : undefined;
 
-  if (hasEnabledFoldersDefined && folderNameToIdMap) {
-    const resolved: string = Array.from(folderNameToIdMap.entries())
-      .map(([name, id]: [string, string]) => `${name}->${id}`)
-      .join(", ");
-    logger.info(
-      `Resolved libraries for enabledLibraries: ${resolved || "none found"}`,
-    );
-  }
-
   if (
     enabledLibraryNames.length > 0 &&
     (folderNameToIdMap?.size === 0 || !folderNameToIdMap)
@@ -134,20 +125,6 @@ export function calculateUserPoliciesDiff(
       currentUserDtoSchema.Policy &&
       userConfig.policy
     ) {
-      if (
-        userConfig.policy.enabledLibraries &&
-        userConfig.policy.enabledLibraries.length > 0
-      ) {
-        const resolvedIds: (string | undefined)[] =
-          userConfig.policy.enabledLibraries.map((name: string) =>
-            folderNameToIdMap?.get(name),
-          );
-
-        logger.info(
-          `User ${userConfig.name} enabledLibraries: ${userConfig.policy.enabledLibraries.join(", ")} -> ${resolvedIds.join(", ")}`,
-        );
-      }
-
       const userPolicyDiff: UserPolicySchema | undefined =
         calculateUserPolicyDiff(
           currentUserDtoSchema.Policy,
@@ -157,9 +134,6 @@ export function calculateUserPoliciesDiff(
 
       if (userPolicyDiff) {
         logger.info(`Updating user policy: ${userConfig.name}`);
-        logger.info(
-          `User ${userConfig.name} policy payload: ${JSON.stringify(userPolicyDiff)}`,
-        );
         userPoliciesToUpdate.set(currentUserDtoSchema.Id, userPolicyDiff);
       }
     }

--- a/src/apply/users.ts
+++ b/src/apply/users.ts
@@ -6,10 +6,15 @@ import type {
   UserConfigList,
   UserPolicyConfig,
 } from "../types/config/users";
-import type { UserDtoSchema, UserPolicySchema } from "../types/schema/users";
+import type {
+  UserDtoSchema,
+  UserPolicySchema,
+  UserConfigurationSchema,
+} from "../types/schema/users";
 import {
   mapUserConfigToCreateSchema,
   mapUserPolicyConfigToSchema,
+  mapUserConfigToConfiguration,
 } from "../mappers/users";
 import { applyChangeset, diff, type IChange } from "json-diff-ts";
 
@@ -87,6 +92,46 @@ export function calculateUserPoliciesDiff(
   return userPoliciesToUpdate.size > 0 ? userPoliciesToUpdate : undefined;
 }
 
+export function calculateUserConfigurationsDiff(
+  current: UserDtoSchema[],
+  desired: UserConfigList,
+): Map<string, UserConfigurationSchema> | undefined {
+  if (desired.length === 0) return undefined;
+
+  const userConfigsToUpdate: Map<string, UserConfigurationSchema> = new Map();
+
+  desired.forEach((userConfig: UserConfig) => {
+    if (
+      typeof userConfig.displayMissingEpisodes === "undefined" &&
+      typeof userConfig.subtitleLanguagePreference === "undefined"
+    ) {
+      return;
+    }
+
+    const currentUserDtoSchema: UserDtoSchema | undefined = current.find(
+      (curr: UserDtoSchema) => curr.Name === userConfig.name,
+    );
+
+    if (currentUserDtoSchema?.Id) {
+      const currentConfig: UserConfigurationSchema =
+        (currentUserDtoSchema.Configuration as UserConfigurationSchema) ?? {};
+      const desiredConfig: Partial<UserConfigurationSchema> =
+        mapUserConfigToConfiguration(userConfig);
+
+      const next: UserConfigurationSchema = {
+        ...currentConfig,
+        ...desiredConfig,
+      };
+
+      if (JSON.stringify(next) !== JSON.stringify(currentConfig)) {
+        userConfigsToUpdate.set(currentUserDtoSchema.Id, next);
+      }
+    }
+  });
+
+  return userConfigsToUpdate.size > 0 ? userConfigsToUpdate : undefined;
+}
+
 export async function applyUserPolicies(
   client: JellyfinClient,
   policies: Map<string, UserPolicySchema> | undefined,
@@ -95,5 +140,16 @@ export async function applyUserPolicies(
 
   for (const [userId, policy] of policies) {
     await client.updateUserPolicy(userId, policy);
+  }
+}
+
+export async function applyUserConfigurations(
+  client: JellyfinClient,
+  configurations: Map<string, UserConfigurationSchema> | undefined,
+): Promise<void> {
+  if (!configurations) return;
+
+  for (const [userId, configuration] of configurations) {
+    await client.updateUserConfiguration(userId, configuration);
   }
 }

--- a/src/apply/users.ts
+++ b/src/apply/users.ts
@@ -1,5 +1,4 @@
 import type { JellyfinClient } from "../api/jellyfin.types";
-import { ChangeSetBuilder } from "../lib/changeset";
 import { logger } from "../lib/logger";
 import type {
   UserConfig,
@@ -16,7 +15,28 @@ import {
   mapUserPolicyConfigToSchema,
   mapUserConfigToConfiguration,
 } from "../mappers/users";
-import { applyChangeset, diff, type IChange } from "json-diff-ts";
+import type { VirtualFolderInfoSchema } from "../types/schema/library";
+
+function buildFolderNameToIdMap(
+  virtualFolders: VirtualFolderInfoSchema[] | undefined,
+): Map<string, string> {
+  const folderNameToIdMap: Map<string, string> = new Map();
+
+  for (const folder of virtualFolders ?? []) {
+    const name: string | undefined = folder.Name ?? undefined;
+    const id: string | undefined =
+      (folder as { Id?: string }).Id ??
+      (folder as { ItemId?: string | null }).ItemId ??
+      undefined;
+
+    if (!name || !id) continue;
+    if (!folderNameToIdMap.has(name)) {
+      folderNameToIdMap.set(name, id);
+    }
+  }
+
+  return folderNameToIdMap;
+}
 
 export function calculateNewUsersDiff(
   current: UserDtoSchema[],
@@ -46,28 +66,63 @@ export async function createNewUsers(
 export function calculateUserPolicyDiff(
   current: UserPolicySchema,
   desired: UserPolicyConfig,
+  folderNameToIdMap?: Map<string, string>,
 ): UserPolicySchema | undefined {
-  const patch: IChange[] = new ChangeSetBuilder(
-    diff(current, mapUserPolicyConfigToSchema(desired)),
-  )
-    .atomize()
-    .withoutRemoves()
-    .toArray();
+  const mapped: Partial<UserPolicySchema> = mapUserPolicyConfigToSchema(
+    desired,
+    folderNameToIdMap,
+  );
 
-  if (patch.length > 0) {
-    return applyChangeset(current, patch) as UserPolicySchema;
-  }
+  const next: UserPolicySchema = { ...current, ...mapped };
 
-  return undefined;
+  return JSON.stringify(next) === JSON.stringify(current) ? undefined : next;
 }
 
 export function calculateUserPoliciesDiff(
   current: UserDtoSchema[],
   desired: UserConfigList,
+  virtualFolders?: VirtualFolderInfoSchema[],
 ): Map<string, UserPolicySchema> | undefined {
   if (desired.length === 0) return undefined;
 
   const userPoliciesToUpdate: Map<string, UserPolicySchema> = new Map();
+  const enabledLibraryNames: string[] = desired
+    .map(
+      (userConfig: UserConfig) =>
+        userConfig.policy?.enabledLibraries ?? undefined,
+    )
+    .filter((names): names is string[] => typeof names !== "undefined")
+    .flat();
+
+  const hasEnabledFoldersDefined: boolean = desired.some(
+    (userConfig: UserConfig) =>
+      typeof userConfig.policy?.enabledLibraries !== "undefined",
+  );
+
+  const folderNameToIdMap: Map<string, string> | undefined =
+    hasEnabledFoldersDefined && virtualFolders
+      ? buildFolderNameToIdMap(virtualFolders)
+      : hasEnabledFoldersDefined
+        ? new Map()
+        : undefined;
+
+  if (hasEnabledFoldersDefined && folderNameToIdMap) {
+    const resolved: string = Array.from(folderNameToIdMap.entries())
+      .map(([name, id]: [string, string]) => `${name}->${id}`)
+      .join(", ");
+    logger.info(
+      `Resolved libraries for enabledLibraries: ${resolved || "none found"}`,
+    );
+  }
+
+  if (
+    enabledLibraryNames.length > 0 &&
+    (folderNameToIdMap?.size === 0 || !folderNameToIdMap)
+  ) {
+    throw new Error(
+      "policy.enabledLibraries provided but no libraries were found to resolve names",
+    );
+  }
 
   desired.forEach((userConfig: UserConfig) => {
     const currentUserDtoSchema: UserDtoSchema | undefined = current.find(
@@ -79,11 +134,32 @@ export function calculateUserPoliciesDiff(
       currentUserDtoSchema.Policy &&
       userConfig.policy
     ) {
+      if (
+        userConfig.policy.enabledLibraries &&
+        userConfig.policy.enabledLibraries.length > 0
+      ) {
+        const resolvedIds: (string | undefined)[] =
+          userConfig.policy.enabledLibraries.map((name: string) =>
+            folderNameToIdMap?.get(name),
+          );
+
+        logger.info(
+          `User ${userConfig.name} enabledLibraries: ${userConfig.policy.enabledLibraries.join(", ")} -> ${resolvedIds.join(", ")}`,
+        );
+      }
+
       const userPolicyDiff: UserPolicySchema | undefined =
-        calculateUserPolicyDiff(currentUserDtoSchema.Policy, userConfig.policy);
+        calculateUserPolicyDiff(
+          currentUserDtoSchema.Policy,
+          userConfig.policy,
+          folderNameToIdMap,
+        );
 
       if (userPolicyDiff) {
         logger.info(`Updating user policy: ${userConfig.name}`);
+        logger.info(
+          `User ${userConfig.name} policy payload: ${JSON.stringify(userPolicyDiff)}`,
+        );
         userPoliciesToUpdate.set(currentUserDtoSchema.Id, userPolicyDiff);
       }
     }

--- a/src/dump/index.ts
+++ b/src/dump/index.ts
@@ -102,6 +102,7 @@ export async function runDump(baseUrl: string): Promise<void> {
     base_url: baseUrl,
 
     system: {
+      serverName: systemConfig.ServerName,
       enableMetrics: systemConfig.EnableMetrics,
       pluginRepositories: systemConfig.PluginRepositories?.map(
         (repo: PluginRepositorySchema) => ({
@@ -114,6 +115,7 @@ export async function runDump(baseUrl: string): Promise<void> {
         enableHwAcceleration:
           systemConfig.TrickplayOptions?.EnableHwAcceleration,
         enableHwEncoding: systemConfig.TrickplayOptions?.EnableHwEncoding,
+        processThreads: systemConfig.TrickplayOptions?.ProcessThreads,
       },
     },
 
@@ -144,6 +146,33 @@ export async function runDump(baseUrl: string): Promise<void> {
             folder.LibraryOptions?.PathInfos?.map((p: MediaPathInfoSchema) => ({
               path: p.Path ?? "",
             })) ?? [],
+          typeOptions: folder.LibraryOptions?.TypeOptions?.map((typeOpt) => ({
+            type: typeOpt.Type ?? "",
+            metadataFetchers: typeOpt.MetadataFetchers ?? [],
+            metadataFetcherOrder: typeOpt.MetadataFetcherOrder ?? undefined,
+            imageFetchers: typeOpt.ImageFetchers ?? [],
+            imageFetcherOrder: typeOpt.ImageFetcherOrder ?? undefined,
+          })),
+          automaticallyAddToCollection:
+            folder.LibraryOptions?.AutomaticallyAddToCollection,
+          enableChapterImageExtraction:
+            folder.LibraryOptions?.EnableChapterImageExtraction,
+          extractChapterImagesDuringLibraryScan:
+            folder.LibraryOptions?.ExtractChapterImagesDuringLibraryScan,
+          extractTrickplayImagesDuringLibraryScan:
+            folder.LibraryOptions?.ExtractTrickplayImagesDuringLibraryScan,
+          enableEmbeddedEpisodeInfos:
+            folder.LibraryOptions?.EnableEmbeddedEpisodeInfos,
+          enableEmbeddedExtraTitles:
+            folder.LibraryOptions?.EnableEmbeddedExtrasTitles,
+          enableTrickplayImageExtraction:
+            folder.LibraryOptions?.EnableTrickplayImageExtraction,
+          saveTrickplayWithMedia: folder.LibraryOptions?.SaveTrickplayWithMedia,
+          metadataSavers: folder.LibraryOptions?.MetadataSavers ?? undefined,
+          saveLocalMetadata: folder.LibraryOptions?.SaveLocalMetadata,
+          automaticRefreshIntervalDays:
+            folder.LibraryOptions?.AutomaticRefreshIntervalDays,
+          enableRealtimeMonitor: folder.LibraryOptions?.EnableRealtimeMonitor,
         },
       })),
     },
@@ -159,8 +188,14 @@ export async function runDump(baseUrl: string): Promise<void> {
       policy: {
         isAdministrator: user.Policy?.IsAdministrator,
         loginAttemptsBeforeLockout: user.Policy?.LoginAttemptsBeforeLockout,
+        enableAllFolders: user.Policy?.EnableAllFolders,
+        enableCollectionManagement: user.Policy?.EnableCollectionManagement,
+        maxActiveSessions: user.Policy?.MaxActiveSessions,
         enabledLibraries: resolveEnabledFolders(user.Policy?.EnabledFolders),
       },
+      displayMissingEpisodes: user.Configuration?.DisplayMissingEpisodes,
+      subtitleLanguagePreference:
+        user.Configuration?.SubtitleLanguagePreference,
     })),
 
     plugins: pluginsWithConfig,

--- a/src/dump/index.ts
+++ b/src/dump/index.ts
@@ -71,6 +71,32 @@ export async function runDump(baseUrl: string): Promise<void> {
     }),
   );
 
+  const folderIdToNameMap: Map<string, string> = new Map(
+    virtualFolders
+      .map((folder: VirtualFolderInfoSchema) => {
+        const name: string | undefined = folder.Name ?? undefined;
+        const id: string | undefined =
+          (folder as { Id?: string }).Id ??
+          (folder as { ItemId?: string | null }).ItemId ??
+          undefined;
+        return name && id ? [id, name] : undefined;
+      })
+      .filter(
+        (
+          entry: [string, string] | undefined | [string, string | undefined],
+        ): entry is [string, string] => Array.isArray(entry),
+      ),
+  );
+
+  const resolveEnabledFolders = (
+    enabledFolderIds: string[] | null | undefined,
+  ): string[] | undefined => {
+    if (!enabledFolderIds) return undefined;
+    return enabledFolderIds.map(
+      (folderId: string) => folderIdToNameMap.get(folderId) ?? folderId,
+    );
+  };
+
   const config: object = {
     version: 1,
     base_url: baseUrl,
@@ -133,6 +159,7 @@ export async function runDump(baseUrl: string): Promise<void> {
       policy: {
         isAdministrator: user.Policy?.IsAdministrator,
         loginAttemptsBeforeLockout: user.Policy?.LoginAttemptsBeforeLockout,
+        enabledLibraries: resolveEnabledFolders(user.Policy?.EnabledFolders),
       },
     })),
 

--- a/src/mappers/library.ts
+++ b/src/mappers/library.ts
@@ -17,6 +17,26 @@ export function mapVirtualFolderConfigToSchema(
         }),
       ),
       TypeOptions: config.libraryOptions.typeOptions,
+      AutomaticallyAddToCollection:
+        config.libraryOptions.automaticallyAddToCollection,
+      EnableChapterImageExtraction:
+        config.libraryOptions.enableChapterImageExtraction,
+      ExtractChapterImagesDuringLibraryScan:
+        config.libraryOptions.extractChapterImagesDuringLibraryScan,
+      ExtractTrickplayImagesDuringLibraryScan:
+        config.libraryOptions.extractTrickplayImagesDuringLibraryScan,
+      EnableEmbeddedEpisodeInfos:
+        config.libraryOptions.enableEmbeddedEpisodeInfos,
+      EnableEmbeddedExtrasTitles:
+        config.libraryOptions.enableEmbeddedExtraTitles,
+      EnableTrickplayImageExtraction:
+        config.libraryOptions.enableTrickplayImageExtraction,
+      SaveTrickplayWithMedia: config.libraryOptions.saveTrickplayWithMedia,
+      MetadataSavers: config.libraryOptions.metadataSavers,
+      SaveLocalMetadata: config.libraryOptions.saveLocalMetadata,
+      AutomaticRefreshIntervalDays:
+        config.libraryOptions.automaticRefreshIntervalDays,
+      EnableRealtimeMonitor: config.libraryOptions.enableRealtimeMonitor,
     } as LibraryOptionsSchema,
   };
 }

--- a/src/mappers/library.ts
+++ b/src/mappers/library.ts
@@ -16,6 +16,7 @@ export function mapVirtualFolderConfigToSchema(
           Path: pathInfo.path,
         }),
       ),
+      TypeOptions: config.libraryOptions.typeOptions,
     } as LibraryOptionsSchema,
   };
 }

--- a/src/mappers/system.ts
+++ b/src/mappers/system.ts
@@ -27,6 +27,7 @@ export function toTrickplayOptionsSchema(
   const out: TrickplayOptionsSchema = {};
   out.EnableHwAcceleration = cfg.enableHwAcceleration;
   out.EnableHwEncoding = cfg.enableHwEncoding;
+  out.ProcessThreads = cfg.processThreads;
   return out;
 }
 

--- a/src/mappers/system.ts
+++ b/src/mappers/system.ts
@@ -36,6 +36,10 @@ export function mapSystemConfigurationConfigToSchema(
 ): Partial<ServerConfigurationSchema> {
   const out: Partial<ServerConfigurationSchema> = {};
 
+  if (desired.serverName !== undefined) {
+    out.ServerName = desired.serverName;
+  }
+
   if (desired.enableMetrics !== undefined) {
     out.EnableMetrics = desired.enableMetrics;
   }

--- a/src/mappers/users.ts
+++ b/src/mappers/users.ts
@@ -30,6 +30,7 @@ export function mapUserConfigToCreateSchema(
 
 export function mapUserPolicyConfigToSchema(
   desired: UserPolicyConfig,
+  folderNameToIdMap?: Map<string, string>,
 ): Partial<UserPolicySchema> {
   const out: Partial<UserPolicySchema> = {};
 
@@ -47,6 +48,33 @@ export function mapUserPolicyConfigToSchema(
 
   if (typeof desired.enableCollectionManagement !== "undefined") {
     out.EnableCollectionManagement = desired.enableCollectionManagement;
+  }
+
+  if (
+    typeof desired.enabledLibraries !== "undefined" &&
+    desired.enabledLibraries.length > 0
+  ) {
+    if (typeof desired.enableAllFolders === "undefined") {
+      out.EnableAllFolders = false;
+    }
+
+    if (!folderNameToIdMap) {
+      throw new Error(
+        "policy.enabledLibraries requires available libraries to resolve names",
+      );
+    }
+
+    out.EnabledFolders = desired.enabledLibraries.map(
+      (folderName: string): string => {
+        const id: string | undefined = folderNameToIdMap.get(folderName);
+        if (!id) {
+          throw new Error(
+            `Library '${folderName}' not found while resolving enabledLibraries`,
+          );
+        }
+        return id;
+      },
+    );
   }
 
   return out;

--- a/src/mappers/users.ts
+++ b/src/mappers/users.ts
@@ -3,6 +3,7 @@ import { type UserConfig, type UserPolicyConfig } from "../types/config/users";
 import {
   type CreateUserByNameSchema,
   type UserPolicySchema,
+  type UserConfigurationSchema,
 } from "../types/schema/users";
 
 export function getPlaintextPassword(config: UserConfig): string | undefined {
@@ -46,6 +47,22 @@ export function mapUserPolicyConfigToSchema(
 
   if (typeof desired.enableCollectionManagement !== "undefined") {
     out.EnableCollectionManagement = desired.enableCollectionManagement;
+  }
+
+  return out;
+}
+
+export function mapUserConfigToConfiguration(
+  desired: UserConfig,
+): Partial<UserConfigurationSchema> {
+  const out: Partial<UserConfigurationSchema> = {};
+
+  if (typeof desired.displayMissingEpisodes !== "undefined") {
+    out.DisplayMissingEpisodes = desired.displayMissingEpisodes;
+  }
+
+  if (typeof desired.subtitleLanguagePreference !== "undefined") {
+    out.SubtitleLanguagePreference = desired.subtitleLanguagePreference;
   }
 
   return out;

--- a/src/mappers/users.ts
+++ b/src/mappers/users.ts
@@ -65,5 +65,9 @@ export function mapUserConfigToConfiguration(
     out.SubtitleLanguagePreference = desired.subtitleLanguagePreference;
   }
 
+  if (typeof desired.maxActiveSessions !== "undefined") {
+    out.MaxActiveSessions = desired.maxActiveSessions;
+  }
+
   return out;
 }

--- a/src/mappers/users.ts
+++ b/src/mappers/users.ts
@@ -40,5 +40,13 @@ export function mapUserPolicyConfigToSchema(
     out.LoginAttemptsBeforeLockout = desired.loginAttemptsBeforeLockout;
   }
 
+  if (typeof desired.enableAllFolders !== "undefined") {
+    out.EnableAllFolders = desired.enableAllFolders;
+  }
+
+  if (typeof desired.enableCollectionManagement !== "undefined") {
+    out.EnableCollectionManagement = desired.enableCollectionManagement;
+  }
+
   return out;
 }

--- a/src/mappers/users.ts
+++ b/src/mappers/users.ts
@@ -42,6 +42,10 @@ export function mapUserPolicyConfigToSchema(
     out.LoginAttemptsBeforeLockout = desired.loginAttemptsBeforeLockout;
   }
 
+  if (typeof desired.maxActiveSessions !== "undefined") {
+    out.MaxActiveSessions = desired.maxActiveSessions;
+  }
+
   if (typeof desired.enableAllFolders !== "undefined") {
     out.EnableAllFolders = desired.enableAllFolders;
   }
@@ -91,10 +95,6 @@ export function mapUserConfigToConfiguration(
 
   if (typeof desired.subtitleLanguagePreference !== "undefined") {
     out.SubtitleLanguagePreference = desired.subtitleLanguagePreference;
-  }
-
-  if (typeof desired.maxActiveSessions !== "undefined") {
-    out.MaxActiveSessions = desired.maxActiveSessions;
   }
 
   return out;

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -19,6 +19,8 @@ import {
   calculateUserPoliciesDiff,
   applyUserPolicies,
   createNewUsers,
+  calculateUserConfigurationsDiff,
+  applyUserConfigurations,
 } from "../apply/users";
 import type { VirtualFolderInfoSchema } from "../types/schema/library";
 import { type ServerConfigurationSchema } from "../types/schema/system";
@@ -149,6 +151,10 @@ export async function runPipeline(path: string): Promise<void> {
 
     const userPoliciesToUpdate: Map<string, UserPolicySchema> | undefined =
       calculateUserPoliciesDiff(currentUsers, cfg.users);
+    const userConfigurationsToUpdate = calculateUserConfigurationsDiff(
+      currentUsers,
+      cfg.users,
+    );
 
     if (userPoliciesToUpdate) {
       console.log("→ updating user policies");
@@ -156,6 +162,14 @@ export async function runPipeline(path: string): Promise<void> {
       console.log("✓ updated user policies");
     } else {
       console.log("✓ user policies already up to date");
+    }
+
+    if (userConfigurationsToUpdate) {
+      console.log("→ updating user configurations");
+      await applyUserConfigurations(jellyfinClient, userConfigurationsToUpdate);
+      console.log("✓ updated user configurations");
+    } else {
+      console.log("✓ user configurations already up to date");
     }
   }
 

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -5,7 +5,11 @@ import {
   calculateEncodingDiff,
   applyEncoding,
 } from "../apply/encoding-options";
-import { calculateLibraryDiff, applyLibrary } from "../apply/library";
+import {
+  calculateLibraryDiff,
+  applyLibrary,
+  type LibraryDiff,
+} from "../apply/library";
 import {
   calculateBrandingOptionsDiff,
   applyBrandingOptions,
@@ -98,12 +102,14 @@ export async function runPipeline(path: string): Promise<void> {
   if (cfg.library?.virtualFolders) {
     const currentVirtualFolders: VirtualFolderInfoSchema[] =
       await jellyfinClient.getVirtualFolders();
-    const foldersToCreate: VirtualFolderInfoSchema[] | undefined =
-      calculateLibraryDiff(currentVirtualFolders, cfg.library.virtualFolders);
+    const libraryDiff: LibraryDiff | undefined = calculateLibraryDiff(
+      currentVirtualFolders,
+      cfg.library.virtualFolders,
+    );
 
-    if (foldersToCreate) {
+    if (libraryDiff) {
       console.log("→ updating library config");
-      await applyLibrary(jellyfinClient, foldersToCreate);
+      await applyLibrary(jellyfinClient, libraryDiff);
       console.log("✓ updated library config");
     } else {
       console.log("✓ library config already up to date");

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -69,6 +69,7 @@ export async function runPipeline(path: string): Promise<void> {
 
   const currentServerConfigurationSchema: ServerConfigurationSchema =
     await jellyfinClient.getSystemConfiguration();
+  let currentVirtualFolders: VirtualFolderInfoSchema[] | undefined;
 
   const updatedServerConfigurationSchema:
     | ServerConfigurationSchema
@@ -102,8 +103,7 @@ export async function runPipeline(path: string): Promise<void> {
   }
 
   if (cfg.library?.virtualFolders) {
-    const currentVirtualFolders: VirtualFolderInfoSchema[] =
-      await jellyfinClient.getVirtualFolders();
+    currentVirtualFolders = await jellyfinClient.getVirtualFolders();
     const libraryDiff: LibraryDiff | undefined = calculateLibraryDiff(
       currentVirtualFolders,
       cfg.library.virtualFolders,
@@ -113,6 +113,7 @@ export async function runPipeline(path: string): Promise<void> {
       console.log("→ updating library config");
       await applyLibrary(jellyfinClient, libraryDiff);
       console.log("✓ updated library config");
+      currentVirtualFolders = await jellyfinClient.getVirtualFolders();
     } else {
       console.log("✓ library config already up to date");
     }
@@ -135,6 +136,16 @@ export async function runPipeline(path: string): Promise<void> {
   }
 
   if (cfg.users) {
+    if (
+      !currentVirtualFolders &&
+      cfg.users.some(
+        (userConfig: UserConfig) =>
+          typeof userConfig.policy?.enabledLibraries !== "undefined",
+      )
+    ) {
+      currentVirtualFolders = await jellyfinClient.getVirtualFolders();
+    }
+
     let currentUsers: UserDtoSchema[] = await jellyfinClient.getUsers();
 
     const usersToCreate: UserConfig[] | undefined = calculateNewUsersDiff(
@@ -150,7 +161,7 @@ export async function runPipeline(path: string): Promise<void> {
     }
 
     const userPoliciesToUpdate: Map<string, UserPolicySchema> | undefined =
-      calculateUserPoliciesDiff(currentUsers, cfg.users);
+      calculateUserPoliciesDiff(currentUsers, cfg.users, currentVirtualFolders);
     const userConfigurationsToUpdate = calculateUserConfigurationsDiff(
       currentUsers,
       cfg.users,

--- a/src/types/config/library.ts
+++ b/src/types/config/library.ts
@@ -18,6 +18,17 @@ export const VirtualFolderConfigType: z.ZodObject<{
         path: z.ZodString;
       }>
     >;
+    typeOptions: z.ZodOptional<
+      z.ZodArray<
+        z.ZodObject<{
+          type: z.ZodString;
+          metadataFetchers: z.ZodArray<z.ZodString>;
+          metadataFetcherOrder: z.ZodOptional<z.ZodArray<z.ZodString>>;
+          imageFetchers: z.ZodArray<z.ZodString>;
+          imageFetcherOrder: z.ZodOptional<z.ZodArray<z.ZodString>>;
+        }>
+      >
+    >;
   }>;
 }> = z
   .object({
@@ -37,6 +48,25 @@ export const VirtualFolderConfigType: z.ZodObject<{
         pathInfos: z
           .array(z.object({ path: z.string().min(1) }).strict())
           .min(1),
+        typeOptions: z
+          .array(
+            z
+              .object({
+                type: z.string().min(1),
+                metadataFetchers: z.array(z.string().min(1)),
+                metadataFetcherOrder: z
+                  .array(z.string().min(1))
+                  .nullable()
+                  .optional(),
+                imageFetchers: z.array(z.string().min(1)),
+                imageFetcherOrder: z
+                  .array(z.string().min(1))
+                  .nullable()
+                  .optional(),
+              })
+              .strict(),
+          )
+          .optional(),
       })
       .strict(),
   })

--- a/src/types/config/library.ts
+++ b/src/types/config/library.ts
@@ -29,6 +29,18 @@ export const VirtualFolderConfigType: z.ZodObject<{
         }>
       >
     >;
+    automaticallyAddToCollection: z.ZodOptional<z.ZodBoolean>;
+    enableChapterImageExtraction: z.ZodOptional<z.ZodBoolean>;
+    extractChapterImagesDuringLibraryScan: z.ZodOptional<z.ZodBoolean>;
+    extractTrickplayImagesDuringLibraryScan: z.ZodOptional<z.ZodBoolean>;
+    enableEmbeddedEpisodeInfos: z.ZodOptional<z.ZodBoolean>;
+    enableEmbeddedExtraTitles: z.ZodOptional<z.ZodBoolean>;
+    enableTrickplayImageExtraction: z.ZodOptional<z.ZodBoolean>;
+    saveTrickplayWithMedia: z.ZodOptional<z.ZodBoolean>;
+    metadataSavers: z.ZodOptional<z.ZodArray<z.ZodString>>;
+    saveLocalMetadata: z.ZodOptional<z.ZodBoolean>;
+    automaticRefreshIntervalDays: z.ZodOptional<z.ZodNumber>;
+    enableRealtimeMonitor: z.ZodOptional<z.ZodBoolean>;
   }>;
 }> = z
   .object({
@@ -67,6 +79,18 @@ export const VirtualFolderConfigType: z.ZodObject<{
               .strict(),
           )
           .optional(),
+        automaticallyAddToCollection: z.boolean().optional(),
+        enableChapterImageExtraction: z.boolean().optional(),
+        extractChapterImagesDuringLibraryScan: z.boolean().optional(),
+        extractTrickplayImagesDuringLibraryScan: z.boolean().optional(),
+        enableEmbeddedEpisodeInfos: z.boolean().optional(),
+        enableEmbeddedExtraTitles: z.boolean().optional(),
+        enableTrickplayImageExtraction: z.boolean().optional(),
+        saveTrickplayWithMedia: z.boolean().optional(),
+        metadataSavers: z.array(z.string().min(1)).optional(),
+        saveLocalMetadata: z.boolean().optional(),
+        automaticRefreshIntervalDays: z.number().int().nonnegative().optional(),
+        enableRealtimeMonitor: z.boolean().optional(),
       })
       .strict(),
   })

--- a/src/types/config/system.ts
+++ b/src/types/config/system.ts
@@ -15,9 +15,11 @@ export type PluginRepositoryConfig = z.infer<typeof PluginRepositoryConfigType>;
 export const TrickplayOptionsConfigType: z.ZodObject<{
   enableHwAcceleration: z.ZodOptional<z.ZodBoolean>;
   enableHwEncoding: z.ZodOptional<z.ZodBoolean>;
+  processThreads: z.ZodOptional<z.ZodNumber>;
 }> = z.object({
   enableHwAcceleration: z.boolean().optional(),
   enableHwEncoding: z.boolean().optional(),
+  processThreads: z.number().int().positive().optional(),
 });
 
 export type TrickplayOptionsConfig = z.infer<typeof TrickplayOptionsConfigType>;

--- a/src/types/config/system.ts
+++ b/src/types/config/system.ts
@@ -25,6 +25,7 @@ export const TrickplayOptionsConfigType: z.ZodObject<{
 export type TrickplayOptionsConfig = z.infer<typeof TrickplayOptionsConfigType>;
 
 export const SystemConfigType: z.ZodObject<{
+  serverName: z.ZodOptional<z.ZodString>;
   enableMetrics: z.ZodOptional<z.ZodBoolean>;
   pluginRepositories: z.ZodOptional<
     z.ZodArray<typeof PluginRepositoryConfigType>
@@ -32,6 +33,7 @@ export const SystemConfigType: z.ZodObject<{
   trickplayOptions: z.ZodOptional<typeof TrickplayOptionsConfigType>;
 }> = z
   .object({
+    serverName: z.string().min(1).optional(),
     enableMetrics: z.boolean().optional(),
     pluginRepositories: z.array(PluginRepositoryConfigType).optional(),
     trickplayOptions: TrickplayOptionsConfigType.optional(),

--- a/src/types/config/users.ts
+++ b/src/types/config/users.ts
@@ -5,11 +5,15 @@ export const UserPolicyConfigType: z.ZodObject<{
   loginAttemptsBeforeLockout: z.ZodOptional<z.ZodNumber>;
   enableAllFolders: z.ZodOptional<z.ZodBoolean>;
   enableCollectionManagement: z.ZodOptional<z.ZodBoolean>;
+  enabledLibraries: z.ZodOptional<z.ZodArray<z.ZodString>>;
 }> = z.object({
   isAdministrator: z.boolean().optional(),
   loginAttemptsBeforeLockout: z.number().int().min(1).optional(),
   enableAllFolders: z.boolean().optional(),
   enableCollectionManagement: z.boolean().optional(),
+  enabledLibraries: z
+    .array(z.string().min(1, "Library name is required"))
+    .optional(),
 });
 
 export type UserPolicyConfig = z.infer<typeof UserPolicyConfigType>;

--- a/src/types/config/users.ts
+++ b/src/types/config/users.ts
@@ -21,6 +21,7 @@ export const UserConfigType: z.ZodObject<{
   policy: z.ZodOptional<typeof UserPolicyConfigType>;
   displayMissingEpisodes: z.ZodOptional<z.ZodBoolean>;
   subtitleLanguagePreference: z.ZodOptional<z.ZodString>;
+  maxActiveSessions: z.ZodOptional<z.ZodNumber>;
 }> = z
   .object({
     name: z.string().min(1, "User name is required"),
@@ -29,6 +30,7 @@ export const UserConfigType: z.ZodObject<{
     policy: UserPolicyConfigType.optional(),
     displayMissingEpisodes: z.boolean().optional(),
     subtitleLanguagePreference: z.string().min(1).optional(),
+    maxActiveSessions: z.number().int().min(1).optional(),
   })
   .strict()
   .refine(

--- a/src/types/config/users.ts
+++ b/src/types/config/users.ts
@@ -3,9 +3,13 @@ import { z } from "zod";
 export const UserPolicyConfigType: z.ZodObject<{
   isAdministrator: z.ZodOptional<z.ZodBoolean>;
   loginAttemptsBeforeLockout: z.ZodOptional<z.ZodNumber>;
+  enableAllFolders: z.ZodOptional<z.ZodBoolean>;
+  enableCollectionManagement: z.ZodOptional<z.ZodBoolean>;
 }> = z.object({
   isAdministrator: z.boolean().optional(),
   loginAttemptsBeforeLockout: z.number().int().min(1).optional(),
+  enableAllFolders: z.boolean().optional(),
+  enableCollectionManagement: z.boolean().optional(),
 });
 
 export type UserPolicyConfig = z.infer<typeof UserPolicyConfigType>;

--- a/src/types/config/users.ts
+++ b/src/types/config/users.ts
@@ -19,12 +19,16 @@ export const UserConfigType: z.ZodObject<{
   password: z.ZodOptional<z.ZodString>;
   passwordFile: z.ZodOptional<z.ZodString>;
   policy: z.ZodOptional<typeof UserPolicyConfigType>;
+  displayMissingEpisodes: z.ZodOptional<z.ZodBoolean>;
+  subtitleLanguagePreference: z.ZodOptional<z.ZodString>;
 }> = z
   .object({
     name: z.string().min(1, "User name is required"),
     password: z.string().optional(),
     passwordFile: z.string().optional(),
     policy: UserPolicyConfigType.optional(),
+    displayMissingEpisodes: z.boolean().optional(),
+    subtitleLanguagePreference: z.string().min(1).optional(),
   })
   .strict()
   .refine(

--- a/src/types/config/users.ts
+++ b/src/types/config/users.ts
@@ -3,12 +3,14 @@ import { z } from "zod";
 export const UserPolicyConfigType: z.ZodObject<{
   isAdministrator: z.ZodOptional<z.ZodBoolean>;
   loginAttemptsBeforeLockout: z.ZodOptional<z.ZodNumber>;
+  maxActiveSessions: z.ZodOptional<z.ZodNumber>;
   enableAllFolders: z.ZodOptional<z.ZodBoolean>;
   enableCollectionManagement: z.ZodOptional<z.ZodBoolean>;
   enabledLibraries: z.ZodOptional<z.ZodArray<z.ZodString>>;
 }> = z.object({
   isAdministrator: z.boolean().optional(),
   loginAttemptsBeforeLockout: z.number().int().min(1).optional(),
+  maxActiveSessions: z.number().int().min(1).optional(),
   enableAllFolders: z.boolean().optional(),
   enableCollectionManagement: z.boolean().optional(),
   enabledLibraries: z

--- a/src/types/schema/library.ts
+++ b/src/types/schema/library.ts
@@ -2,6 +2,8 @@ import type { components } from "../../../generated/schema";
 
 export type AddVirtualFolderDtoSchema =
   components["schemas"]["AddVirtualFolderDto"];
+export type UpdateLibraryOptionsDtoSchema =
+  components["schemas"]["UpdateLibraryOptionsDto"];
 
 export type VirtualFolderInfoSchema =
   components["schemas"]["VirtualFolderInfo"];

--- a/src/types/schema/users.ts
+++ b/src/types/schema/users.ts
@@ -3,3 +3,5 @@ import type { components } from "../../../generated/schema";
 export type UserDtoSchema = components["schemas"]["UserDto"];
 export type CreateUserByNameSchema = components["schemas"]["CreateUserByName"];
 export type UserPolicySchema = components["schemas"]["UserPolicy"];
+export type UserConfigurationSchema =
+  components["schemas"]["UserConfiguration"];

--- a/tests/apply/library.spec.ts
+++ b/tests/apply/library.spec.ts
@@ -14,52 +14,40 @@ import { logger } from "../../src/lib/logger";
 describe("apply/library", () => {
   let mockClient: JellyfinClient;
   let addVirtualFolderSpy: Mock;
-  let loggerSpy: Mock;
+  let updateLibraryOptionsSpy: Mock;
+  let loggerInfoSpy: Mock;
+  let loggerWarnSpy: Mock;
 
   beforeEach(() => {
     vi.clearAllMocks();
 
     addVirtualFolderSpy = vi.fn();
-    loggerSpy = vi.spyOn(logger, "info").mockImplementation(() => undefined);
-    vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+    updateLibraryOptionsSpy = vi.fn();
+    loggerInfoSpy = vi
+      .spyOn(logger, "info")
+      .mockImplementation(() => undefined);
+    loggerWarnSpy = vi
+      .spyOn(logger, "warn")
+      .mockImplementation(() => undefined);
 
     mockClient = {
       addVirtualFolder: addVirtualFolderSpy,
+      updateLibraryOptions: updateLibraryOptionsSpy,
     } as unknown as JellyfinClient;
   });
 
   describe("calculateLibraryDiff", () => {
     it("should return undefined when no virtual folders specified", () => {
-      // Arrange
-      const currentVirtualFolders: VirtualFolderInfoSchema[] = [];
-      const desired: VirtualFolderConfig[] = [];
-
-      // Act
-      const result: VirtualFolderInfoSchema[] | undefined =
-        calculateLibraryDiff(currentVirtualFolders, desired);
-
-      // Assert
+      const result = calculateLibraryDiff([], []);
       expect(result).toBeUndefined();
     });
 
     it("should return undefined when empty virtual folders array", () => {
-      // Arrange
-      const currentVirtualFolders: VirtualFolderInfoSchema[] = [];
-      const desired: LibraryConfig = { virtualFolders: [] };
-
-      // Act
-      const result: VirtualFolderInfoSchema[] | undefined =
-        calculateLibraryDiff(
-          currentVirtualFolders,
-          desired.virtualFolders as VirtualFolderConfig[],
-        );
-
-      // Assert
+      const result = calculateLibraryDiff([], []);
       expect(result).toBeUndefined();
     });
 
     it("should return config with new virtual folder to create", () => {
-      // Arrange
       const currentVirtualFolders: VirtualFolderInfoSchema[] = [];
       const desired: LibraryConfig = {
         virtualFolders: [
@@ -73,15 +61,12 @@ describe("apply/library", () => {
         ],
       };
 
-      // Act
-      const result: VirtualFolderInfoSchema[] | undefined =
-        calculateLibraryDiff(
-          currentVirtualFolders,
-          desired.virtualFolders as VirtualFolderConfig[],
-        );
+      const result = calculateLibraryDiff(
+        currentVirtualFolders,
+        desired.virtualFolders as VirtualFolderConfig[],
+      );
 
-      // Assert
-      expect(result).toEqual([
+      expect(result?.toCreate).toEqual([
         {
           Name: "Movies",
           CollectionType: "movies",
@@ -90,12 +75,13 @@ describe("apply/library", () => {
           },
         },
       ]);
+      expect(result?.toUpdate).toBeUndefined();
     });
 
     it("should return undefined for existing virtual folder with matching locations", () => {
-      // Arrange
       const currentVirtualFolders: VirtualFolderInfoSchema[] = [
         {
+          ItemId: "1",
           Name: "Movies",
           CollectionType: "movies",
           LibraryOptions: {
@@ -115,21 +101,18 @@ describe("apply/library", () => {
         ],
       };
 
-      // Act
-      const result: VirtualFolderInfoSchema[] | undefined =
-        calculateLibraryDiff(
-          currentVirtualFolders,
-          desired.virtualFolders as VirtualFolderConfig[],
-        );
+      const result = calculateLibraryDiff(
+        currentVirtualFolders,
+        desired.virtualFolders as VirtualFolderConfig[],
+      );
 
-      // Assert
       expect(result).toBeUndefined();
     });
 
     it("should return undefined for existing virtual folder with matching locations regardless of order", () => {
-      // Arrange
       const currentVirtualFolders: VirtualFolderInfoSchema[] = [
         {
+          ItemId: "1",
           Name: "Movies",
           CollectionType: "movies",
           LibraryOptions: {
@@ -157,21 +140,18 @@ describe("apply/library", () => {
         ],
       };
 
-      // Act
-      const result: VirtualFolderInfoSchema[] | undefined =
-        calculateLibraryDiff(
-          currentVirtualFolders,
-          desired.virtualFolders as VirtualFolderConfig[],
-        );
+      const result = calculateLibraryDiff(
+        currentVirtualFolders,
+        desired.virtualFolders as VirtualFolderConfig[],
+      );
 
-      // Assert
       expect(result).toBeUndefined();
     });
 
-    it("should return empty config for virtual folder needing update", () => {
-      // Arrange
+    it("should return update for virtual folder needing option changes", () => {
       const currentVirtualFolders: VirtualFolderInfoSchema[] = [
         {
+          ItemId: "1",
           Name: "Movies",
           CollectionType: "movies",
           LibraryOptions: {
@@ -191,21 +171,25 @@ describe("apply/library", () => {
         ],
       };
 
-      // Act
-      const result: VirtualFolderInfoSchema[] | undefined =
-        calculateLibraryDiff(
-          currentVirtualFolders,
-          desired.virtualFolders as VirtualFolderConfig[],
-        );
+      const result = calculateLibraryDiff(
+        currentVirtualFolders,
+        desired.virtualFolders as VirtualFolderConfig[],
+      );
 
-      // Assert
-      expect(result).toBeUndefined();
+      expect(result?.toCreate).toBeUndefined();
+      expect(result?.toUpdate).toEqual([
+        {
+          id: "1",
+          name: "Movies",
+          libraryOptions: { PathInfos: [{ Path: "/path/new" }] },
+        },
+      ]);
     });
 
-    it("should return undefined when existing folder has different collectionType", () => {
-      // Arrange
+    it("should return update when typeOptions additions are present", () => {
       const currentVirtualFolders: VirtualFolderInfoSchema[] = [
         {
+          ItemId: "movies-id",
           Name: "Movies",
           CollectionType: "movies",
           LibraryOptions: {
@@ -213,33 +197,54 @@ describe("apply/library", () => {
           } as LibraryOptionsSchema,
         },
       ];
+
       const desired: LibraryConfig = {
         virtualFolders: [
           {
             name: "Movies",
-            collectionType: "tvshows",
+            collectionType: "movies",
             libraryOptions: {
               pathInfos: [{ path: "/data/movies" }],
+              typeOptions: [
+                {
+                  type: "Movie",
+                  metadataFetchers: [],
+                  imageFetchers: [],
+                },
+              ],
             },
           },
         ],
       };
 
-      // Act
-      const result: VirtualFolderInfoSchema[] | undefined =
-        calculateLibraryDiff(
-          currentVirtualFolders,
-          desired.virtualFolders as VirtualFolderConfig[],
-        );
+      const result = calculateLibraryDiff(
+        currentVirtualFolders,
+        desired.virtualFolders as VirtualFolderConfig[],
+      );
 
-      // Assert - withoutUpdates() filters the CollectionType change
-      expect(result).toBeUndefined();
+      expect(result?.toUpdate).toEqual([
+        {
+          id: "movies-id",
+          name: "Movies",
+          libraryOptions: {
+            PathInfos: [{ Path: "/data/movies" }],
+            TypeOptions: [
+              {
+                type: "Movie",
+                metadataFetchers: [],
+                imageFetchers: [],
+              },
+            ],
+          },
+        },
+      ]);
+      expect(result?.toCreate).toBeUndefined();
     });
 
     it("should handle mixed create and existing scenarios", () => {
-      // Arrange
       const currentVirtualFolders: VirtualFolderInfoSchema[] = [
         {
+          ItemId: "existing-id",
           Name: "Existing Movies",
           CollectionType: "movies",
           LibraryOptions: {
@@ -266,15 +271,12 @@ describe("apply/library", () => {
         ],
       };
 
-      // Act
-      const result: VirtualFolderInfoSchema[] | undefined =
-        calculateLibraryDiff(
-          currentVirtualFolders,
-          desired.virtualFolders as VirtualFolderConfig[],
-        );
+      const result = calculateLibraryDiff(
+        currentVirtualFolders,
+        desired.virtualFolders as VirtualFolderConfig[],
+      );
 
-      // Assert
-      expect(result).toEqual([
+      expect(result?.toCreate).toEqual([
         {
           Name: "Test Shows",
           CollectionType: "tvshows",
@@ -283,94 +285,108 @@ describe("apply/library", () => {
           },
         },
       ]);
+      expect(result?.toUpdate).toBeUndefined();
     });
   });
 
   describe("applyLibrary", () => {
     it("should do nothing when config is undefined", async () => {
-      // Act
       await applyLibrary(mockClient, undefined);
 
-      // Assert
       expect(addVirtualFolderSpy).not.toHaveBeenCalled();
+      expect(updateLibraryOptionsSpy).not.toHaveBeenCalled();
     });
 
     it("should do nothing when no virtual folders in config", async () => {
-      // Act
-      await applyLibrary(mockClient, []);
+      await applyLibrary(mockClient, {});
 
-      // Assert
       expect(addVirtualFolderSpy).not.toHaveBeenCalled();
+      expect(updateLibraryOptionsSpy).not.toHaveBeenCalled();
+    });
+
+    it("should skip entries without Name", async () => {
+      const diff = {
+        toCreate: [
+          {
+            CollectionType: "movies",
+            LibraryOptions: {
+              PathInfos: [{ Path: "/data" }],
+            } as LibraryOptionsSchema,
+          },
+        ] as VirtualFolderInfoSchema[],
+      };
+
+      await applyLibrary(mockClient, diff);
+
+      expect(loggerWarnSpy).toHaveBeenCalledWith(
+        "Skipping virtual folder without a Name",
+      );
+      expect(addVirtualFolderSpy).not.toHaveBeenCalled();
+      expect(updateLibraryOptionsSpy).not.toHaveBeenCalled();
     });
 
     it("should create new virtual folder", async () => {
-      // Arrange
-      const virtualFoldersToAdd: VirtualFolderInfoSchema[] = [
-        {
-          Name: "Movies",
-          CollectionType: "movies",
-          LibraryOptions: {
-            PathInfos: [{ Path: "/data/movies" }],
-          } as LibraryOptionsSchema,
-        },
-      ];
+      const diff = {
+        toCreate: [
+          {
+            Name: "Movies",
+            CollectionType: "movies",
+            LibraryOptions: {
+              PathInfos: [{ Path: "/data/movies" }],
+            } as LibraryOptionsSchema,
+          },
+        ] as VirtualFolderInfoSchema[],
+      };
 
       addVirtualFolderSpy.mockResolvedValue(undefined);
 
-      // Act
-      await applyLibrary(mockClient, virtualFoldersToAdd);
+      await applyLibrary(mockClient, diff);
 
-      // Assert
       expect(addVirtualFolderSpy).toHaveBeenCalledTimes(1);
       expect(addVirtualFolderSpy).toHaveBeenCalledWith("Movies", "movies", {
         LibraryOptions: {
           PathInfos: [{ Path: "/data/movies" }],
         },
       });
-      expect(loggerSpy).toHaveBeenCalledWith("Creating virtual folder: Movies");
-      expect(loggerSpy).toHaveBeenCalledWith(
+      expect(loggerInfoSpy).toHaveBeenCalledWith(
+        "Creating virtual folder: Movies",
+      );
+      expect(loggerInfoSpy).toHaveBeenCalledWith(
         "✓ Created virtual folder: Movies (movies)",
       );
+      expect(updateLibraryOptionsSpy).not.toHaveBeenCalled();
     });
 
-    it("should create multiple new virtual folders", async () => {
-      // Arrange
-      const virtualFoldersToAdd: VirtualFolderInfoSchema[] = [
-        {
-          Name: "Movies",
-          CollectionType: "movies",
-          LibraryOptions: {
-            PathInfos: [{ Path: "/data/movies" }],
-          } as LibraryOptionsSchema,
+    it("should update library options for existing folder", async () => {
+      const diff = {
+        toUpdate: [
+          {
+            id: "movies-id",
+            name: "Movies",
+            libraryOptions: {
+              PathInfos: [{ Path: "/data/movies" }],
+              TypeOptions: [
+                { type: "Movie", metadataFetchers: [], imageFetchers: [] },
+              ],
+            } as LibraryOptionsSchema,
+          },
+        ],
+      };
+
+      updateLibraryOptionsSpy.mockResolvedValue(undefined);
+
+      await applyLibrary(mockClient, diff);
+
+      expect(updateLibraryOptionsSpy).toHaveBeenCalledWith("movies-id", {
+        Id: "movies-id",
+        LibraryOptions: {
+          PathInfos: [{ Path: "/data/movies" }],
+          TypeOptions: [
+            { type: "Movie", metadataFetchers: [], imageFetchers: [] },
+          ],
         },
-        {
-          Name: "TV Shows",
-          CollectionType: "tvshows",
-          LibraryOptions: {
-            PathInfos: [{ Path: "/data/shows" }],
-          } as LibraryOptionsSchema,
-        },
-      ];
-
-      addVirtualFolderSpy.mockResolvedValue(undefined);
-
-      // Act
-      await applyLibrary(mockClient, virtualFoldersToAdd);
-
-      // Assert
-      expect(addVirtualFolderSpy).toHaveBeenCalledTimes(2);
-      expect(addVirtualFolderSpy).toHaveBeenNthCalledWith(
-        1,
-        "Movies",
-        "movies",
-        expect.any(Object),
-      );
-      expect(addVirtualFolderSpy).toHaveBeenNthCalledWith(
-        2,
-        "TV Shows",
-        "tvshows",
-        expect.any(Object),
-      );
+      });
+      expect(addVirtualFolderSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/apply/library.spec.ts
+++ b/tests/apply/library.spec.ts
@@ -230,6 +230,53 @@ describe("apply/library", () => {
       ]);
     });
 
+    it("should return update when additional library options change", () => {
+      const currentVirtualFolders: VirtualFolderInfoSchema[] = [
+        {
+          ItemId: "1",
+          Name: "Movies",
+          CollectionType: "movies",
+          LibraryOptions: {
+            PathInfos: [{ Path: "/data/movies" }],
+            AutomaticallyAddToCollection: false,
+            EnableTrickplayImageExtraction: false,
+            MetadataSavers: [],
+          } as LibraryOptionsSchema,
+        },
+      ];
+      const desired: LibraryConfig = {
+        virtualFolders: [
+          {
+            name: "Movies",
+            collectionType: "movies",
+            libraryOptions: {
+              pathInfos: [{ path: "/data/movies" }],
+              automaticallyAddToCollection: true,
+              enableTrickplayImageExtraction: true,
+              metadataSavers: ["Nfo"],
+            },
+          },
+        ],
+      };
+
+      const result = calculateLibraryDiff(
+        currentVirtualFolders,
+        desired.virtualFolders as VirtualFolderConfig[],
+      );
+
+      expect(result?.toCreate).toBeUndefined();
+      expect(result?.toUpdate?.[0]).toMatchObject({
+        id: "1",
+        name: "Movies",
+        libraryOptions: {
+          PathInfos: [{ Path: "/data/movies" }],
+          AutomaticallyAddToCollection: true,
+          EnableTrickplayImageExtraction: true,
+          MetadataSavers: ["Nfo"],
+        },
+      });
+    });
+
     it("should return update when typeOptions additions are present", () => {
       const currentVirtualFolders: VirtualFolderInfoSchema[] = [
         {

--- a/tests/apply/library.spec.ts
+++ b/tests/apply/library.spec.ts
@@ -109,7 +109,7 @@ describe("apply/library", () => {
       expect(result).toBeUndefined();
     });
 
-    it("should return undefined for existing virtual folder with matching locations regardless of order", () => {
+    it("should return update for existing virtual folder when path order changes", () => {
       const currentVirtualFolders: VirtualFolderInfoSchema[] = [
         {
           ItemId: "1",
@@ -145,7 +145,20 @@ describe("apply/library", () => {
         desired.virtualFolders as VirtualFolderConfig[],
       );
 
-      expect(result).toBeUndefined();
+      expect(result?.toCreate).toBeUndefined();
+      expect(result?.toUpdate).toEqual([
+        {
+          id: "1",
+          name: "Movies",
+          libraryOptions: {
+            PathInfos: [
+              { Path: "/data/path1" },
+              { Path: "/data/path2" },
+              { Path: "/data/path3" },
+            ],
+          },
+        },
+      ]);
     });
 
     it("should return update for virtual folder needing option changes", () => {

--- a/tests/apply/library.spec.ts
+++ b/tests/apply/library.spec.ts
@@ -161,6 +161,37 @@ describe("apply/library", () => {
       ]);
     });
 
+    it("should throw when collectionType changes", () => {
+      const currentVirtualFolders: VirtualFolderInfoSchema[] = [
+        {
+          ItemId: "1",
+          Name: "Movies",
+          CollectionType: "movies",
+          LibraryOptions: {
+            PathInfos: [{ Path: "/data/movies" }],
+          } as LibraryOptionsSchema,
+        },
+      ];
+      const desired: LibraryConfig = {
+        virtualFolders: [
+          {
+            name: "Movies",
+            collectionType: "tvshows",
+            libraryOptions: {
+              pathInfos: [{ path: "/data/movies" }],
+            },
+          },
+        ],
+      };
+
+      expect(() =>
+        calculateLibraryDiff(
+          currentVirtualFolders,
+          desired.virtualFolders as VirtualFolderConfig[],
+        ),
+      ).toThrow(/collectionType change is not supported/i);
+    });
+
     it("should return update for virtual folder needing option changes", () => {
       const currentVirtualFolders: VirtualFolderInfoSchema[] = [
         {

--- a/tests/apply/system.spec.ts
+++ b/tests/apply/system.spec.ts
@@ -51,6 +51,68 @@ describe("apply/system", () => {
   });
 
   describe("calculateSystemDiff", () => {
+    describe("serverName (Scalar String)", () => {
+      it("should preserve ServerName when serverName is undefined", () => {
+        // Arrange
+        const current: ServerConfigurationSchema = {
+          ServerName: "CurrentServer",
+          EnableMetrics: false,
+          PluginRepositories: [],
+          TrickplayOptions: undefined,
+        } as ServerConfigurationSchema;
+
+        const desired: SystemConfig = {};
+
+        // Act
+        const result: ServerConfigurationSchema | undefined =
+          calculateSystemDiff(current, desired);
+
+        // Assert
+        expect(result).toBeUndefined();
+      });
+
+      it("should update ServerName when serverName changes", () => {
+        // Arrange
+        const current: ServerConfigurationSchema = {
+          ServerName: "OldServer",
+          EnableMetrics: false,
+          PluginRepositories: [],
+          TrickplayOptions: undefined,
+        } as ServerConfigurationSchema;
+
+        const desired: SystemConfig = { serverName: "NewServer" };
+
+        // Act
+        const result: ServerConfigurationSchema | undefined =
+          calculateSystemDiff(current, desired);
+
+        // Assert
+        expect(result?.ServerName).toBe("NewServer");
+        expect(result?.EnableMetrics).toBe(false);
+        expect(result?.PluginRepositories).toEqual([]);
+        expect(result?.TrickplayOptions).toBeUndefined();
+      });
+
+      it("should not modify ServerName when value is the same", () => {
+        // Arrange
+        const current: ServerConfigurationSchema = {
+          ServerName: "SameServer",
+          EnableMetrics: false,
+          PluginRepositories: [],
+          TrickplayOptions: undefined,
+        } as ServerConfigurationSchema;
+
+        const desired: SystemConfig = { serverName: "SameServer" };
+
+        // Act
+        const result: ServerConfigurationSchema | undefined =
+          calculateSystemDiff(current, desired);
+
+        // Assert
+        expect(result).toBeUndefined();
+      });
+    });
+
     describe("enableMetrics (Scalar Boolean)", () => {
       it("should preserve EnableMetrics when enableMetrics is undefined (current: true)", () => {
         // Arrange

--- a/tests/apply/users.spec.ts
+++ b/tests/apply/users.spec.ts
@@ -4,12 +4,15 @@ import {
   createNewUsers,
   calculateUserPoliciesDiff,
   applyUserPolicies,
+  calculateUserConfigurationsDiff,
+  applyUserConfigurations,
 } from "../../src/apply/users";
 import type { JellyfinClient } from "../../src/api/jellyfin.types";
 import type { UserConfig, UserConfigList } from "../../src/types/config/users";
 import type {
   UserDtoSchema,
   UserPolicySchema,
+  UserConfigurationSchema,
 } from "../../src/types/schema/users";
 vi.mock("../../src/lib/logger", () => ({
   logger: {
@@ -377,6 +380,50 @@ describe("calculateUserPoliciesDiff", () => {
         },
       } as UserDtoSchema,
     ];
+  });
+
+  describe("calculateUserConfigurationsDiff", () => {
+    it("should return undefined when no configuration fields provided", () => {
+      const current: UserDtoSchema[] = [
+        {
+          Id: "1",
+          Name: "user",
+          Configuration: {} as UserConfigurationSchema,
+        },
+      ];
+      const desired: UserConfigList = [
+        { name: "user", password: "pass" } as UserConfig,
+      ];
+
+      expect(calculateUserConfigurationsDiff(current, desired)).toBeUndefined();
+    });
+
+    it("should return configuration update when fields differ", () => {
+      const current: UserDtoSchema[] = [
+        {
+          Id: "1",
+          Name: "user",
+          Configuration: {
+            DisplayMissingEpisodes: false,
+          } as UserConfigurationSchema,
+        },
+      ];
+      const desired: UserConfigList = [
+        {
+          name: "user",
+          password: "pass",
+          displayMissingEpisodes: true,
+          subtitleLanguagePreference: "eng",
+        } as UserConfig,
+      ];
+
+      const result = calculateUserConfigurationsDiff(current, desired);
+
+      expect(result?.get("1")).toEqual({
+        DisplayMissingEpisodes: true,
+        SubtitleLanguagePreference: "eng",
+      });
+    });
   });
 
   it("should return undefined when no users desired", () => {

--- a/tests/apply/users.spec.ts
+++ b/tests/apply/users.spec.ts
@@ -33,6 +33,7 @@ vi.mock("../../src/mappers/users", () => ({
       policy: {
         isAdministrator?: boolean;
         loginAttemptsBeforeLockout?: number;
+        maxActiveSessions?: number;
         enabledLibraries?: string[];
       },
       folderNameToIdMap?: Map<string, string>,
@@ -43,6 +44,9 @@ vi.mock("../../src/mappers/users", () => ({
       }
       if (policy.loginAttemptsBeforeLockout !== undefined) {
         result.LoginAttemptsBeforeLockout = policy.loginAttemptsBeforeLockout;
+      }
+      if (policy.maxActiveSessions !== undefined) {
+        result.MaxActiveSessions = policy.maxActiveSessions;
       }
       if (policy.enabledLibraries !== undefined) {
         result.EnabledFolders = policy.enabledLibraries.map((name: string) => {
@@ -468,6 +472,29 @@ describe("calculateUserPoliciesDiff", () => {
 
     // Assert
     expect(result).toBeUndefined();
+  });
+
+  it("should update policy when maxActiveSessions is provided without policy", () => {
+    // Arrange
+    const config: UserConfigList = [
+      {
+        name: "existing-user",
+        password: "password",
+        maxActiveSessions: 2,
+      },
+    ];
+
+    // Act
+    const result: Map<string, UserPolicySchema> | undefined =
+      calculateUserPoliciesDiff(currentUsers, config);
+
+    // Assert
+    expect(result).toBeDefined();
+    expect(result?.size).toBe(1);
+    const updatedPolicy: UserPolicySchema | undefined =
+      result?.get("user-1-id");
+    expect(updatedPolicy?.MaxActiveSessions).toBe(2);
+    expect(updatedPolicy?.IsAdministrator).toBe(false);
   });
 
   it("should return undefined when no user policies change", () => {

--- a/tests/apply/users.spec.ts
+++ b/tests/apply/users.spec.ts
@@ -14,6 +14,7 @@ import type {
   UserPolicySchema,
   UserConfigurationSchema,
 } from "../../src/types/schema/users";
+import type { VirtualFolderInfoSchema } from "../../src/types/schema/library";
 vi.mock("../../src/lib/logger", () => ({
   logger: {
     info: vi.fn(),
@@ -28,16 +29,27 @@ vi.mock("../../src/mappers/users", () => ({
     Password: config.password ?? "mocked-password-from-file",
   })),
   mapUserPolicyConfigToSchema: vi.fn(
-    (policy: {
-      isAdministrator?: boolean;
-      loginAttemptsBeforeLockout?: number;
-    }) => {
-      const result: Record<string, boolean | number> = {};
+    (
+      policy: {
+        isAdministrator?: boolean;
+        loginAttemptsBeforeLockout?: number;
+        enabledLibraries?: string[];
+      },
+      folderNameToIdMap?: Map<string, string>,
+    ) => {
+      const result: Record<string, boolean | number | string[]> = {};
       if (policy.isAdministrator !== undefined) {
         result.IsAdministrator = policy.isAdministrator;
       }
       if (policy.loginAttemptsBeforeLockout !== undefined) {
         result.LoginAttemptsBeforeLockout = policy.loginAttemptsBeforeLockout;
+      }
+      if (policy.enabledLibraries !== undefined) {
+        result.EnabledFolders = policy.enabledLibraries.map((name: string) => {
+          const id: string | undefined = folderNameToIdMap?.get(name);
+          if (!id) throw new Error(`Missing id for ${name}`);
+          return id;
+        });
       }
       return result;
     },
@@ -575,6 +587,85 @@ describe("calculateUserPoliciesDiff", () => {
       result?.get("user-2-id");
     expect(updatedPolicy?.LoginAttemptsBeforeLockout).toBe(10);
     expect(updatedPolicy?.IsAdministrator).toBe(true);
+  });
+
+  it("should resolve enabledLibraries to library ids", () => {
+    const virtualFolders: VirtualFolderInfoSchema[] = [
+      {
+        Name: "Movies",
+        Id: "library-1",
+      } as VirtualFolderInfoSchema,
+    ];
+
+    const config: UserConfigList = [
+      {
+        name: "existing-user",
+        password: "password",
+        policy: {
+          enabledLibraries: ["Movies"],
+        },
+      },
+    ];
+
+    const result: Map<string, UserPolicySchema> | undefined =
+      calculateUserPoliciesDiff(currentUsers, config, virtualFolders);
+
+    expect(result?.get("user-1-id")?.EnabledFolders).toEqual(["library-1"]);
+    expect(result?.get("user-1-id")?.IsAdministrator).toBe(false);
+  });
+
+  it("should merge resolved enabledLibraries into existing policy", () => {
+    const virtualFolders: VirtualFolderInfoSchema[] = [
+      { Name: "Family", Id: "family-id" } as VirtualFolderInfoSchema,
+    ];
+
+    const config: UserConfigList = [
+      {
+        name: "existing-user",
+        password: "password",
+        policy: {
+          enabledLibraries: ["Family"],
+        },
+      },
+    ];
+
+    const current: UserDtoSchema[] = [
+      {
+        Name: "existing-user",
+        Id: "user-1-id",
+        Policy: {
+          IsAdministrator: false,
+          LoginAttemptsBeforeLockout: 5,
+          EnableAllFolders: true,
+        },
+      } as UserDtoSchema,
+    ];
+
+    const result = calculateUserPoliciesDiff(current, config, virtualFolders);
+    const payload: UserPolicySchema | undefined = result?.get("user-1-id");
+
+    expect(payload).toEqual(
+      expect.objectContaining({
+        IsAdministrator: false,
+        LoginAttemptsBeforeLockout: 5,
+        EnableAllFolders: false,
+        EnabledFolders: ["family-id"],
+      }),
+    );
+  });
+
+  it("should throw when enabledLibraries are provided but libraries are unavailable", () => {
+    const config: UserConfigList = [
+      {
+        name: "existing-user",
+        password: "password",
+        policy: {
+          enabledLibraries: ["Movies"],
+        },
+      },
+    ];
+
+    expect(() => calculateUserPoliciesDiff(currentUsers, config)).toThrow();
   });
 
   it("should not modify policy when loginAttemptsBeforeLockout value is the same", () => {

--- a/tests/mappers/system.spec.ts
+++ b/tests/mappers/system.spec.ts
@@ -188,6 +188,7 @@ describe("mappers/system", () => {
     it("should map trickplayOptions to TrickplayOptions", () => {
       // Arrange
       const config: SystemConfig = {
+        serverName: "MyServer",
         trickplayOptions: {
           enableHwAcceleration: true,
           enableHwEncoding: false,
@@ -201,6 +202,7 @@ describe("mappers/system", () => {
 
       // Assert
       expect(result).toEqual({
+        ServerName: "MyServer",
         TrickplayOptions: {
           EnableHwAcceleration: true,
           EnableHwEncoding: false,

--- a/tests/mappers/system.spec.ts
+++ b/tests/mappers/system.spec.ts
@@ -191,6 +191,7 @@ describe("mappers/system", () => {
         trickplayOptions: {
           enableHwAcceleration: true,
           enableHwEncoding: false,
+          processThreads: 2,
         },
       };
 
@@ -203,6 +204,7 @@ describe("mappers/system", () => {
         TrickplayOptions: {
           EnableHwAcceleration: true,
           EnableHwEncoding: false,
+          ProcessThreads: 2,
         },
       });
     });

--- a/tests/mappers/users.spec.ts
+++ b/tests/mappers/users.spec.ts
@@ -249,6 +249,8 @@ describe("mappers/users", () => {
       const config: UserPolicyConfig = {
         isAdministrator: true,
         loginAttemptsBeforeLockout: 5,
+        enableAllFolders: true,
+        enableCollectionManagement: false,
       };
 
       // Act
@@ -259,6 +261,8 @@ describe("mappers/users", () => {
       expect(result).toEqual({
         IsAdministrator: true,
         LoginAttemptsBeforeLockout: 5,
+        EnableAllFolders: true,
+        EnableCollectionManagement: false,
       });
     });
 

--- a/tests/mappers/users.spec.ts
+++ b/tests/mappers/users.spec.ts
@@ -353,6 +353,68 @@ describe("mappers/users", () => {
       });
     });
 
+    it("should map enabledLibraries to ids when map provided", () => {
+      const folderMap: Map<string, string> = new Map([
+        ["Movies", "folder-1"],
+        ["Shows", "folder-2"],
+      ]);
+
+      const config: UserPolicyConfig = {
+        enabledLibraries: ["Movies", "Shows"],
+      };
+
+      const result: Partial<UserPolicySchema> = mapUserPolicyConfigToSchema(
+        config,
+        folderMap,
+      );
+
+      expect(result).toEqual({
+        EnableAllFolders: false,
+        EnabledFolders: ["folder-1", "folder-2"],
+      });
+    });
+
+    it("should throw when enabledLibraries are provided without a map", () => {
+      const config: UserPolicyConfig = {
+        enabledLibraries: ["Movies"],
+      };
+
+      expect(() => mapUserPolicyConfigToSchema(config)).toThrow();
+    });
+
+    it("should throw when library name cannot be resolved", () => {
+      const folderMap: Map<string, string> = new Map([["Shows", "folder-2"]]);
+
+      const config: UserPolicyConfig = {
+        enabledLibraries: ["Movies"],
+      };
+
+      expect(() => mapUserPolicyConfigToSchema(config, folderMap)).toThrowError(
+        /Movies/,
+      );
+    });
+
+    it("should throw when enabledLibraries map resolves to empty ids", () => {
+      const folderMap: Map<string, string> = new Map();
+      const config: UserPolicyConfig = { enabledLibraries: ["Movies"] };
+
+      expect(() => mapUserPolicyConfigToSchema(config, folderMap)).toThrowError(
+        /no matching library ids/,
+      );
+    });
+
+    it("should ignore enabledLibraries when empty", () => {
+      const folderMap: Map<string, string> = new Map([["Movies", "id"]]);
+      const config: UserPolicyConfig = { enabledLibraries: [] };
+
+      const result: Partial<UserPolicySchema> = mapUserPolicyConfigToSchema(
+        config,
+        folderMap,
+      );
+
+      expect(result).toEqual({});
+    });
+
     it("should handle zero value for loginAttemptsBeforeLockout", () => {
       // Arrange
       const config: UserPolicyConfig = {

--- a/tests/mappers/users.spec.ts
+++ b/tests/mappers/users.spec.ts
@@ -6,6 +6,7 @@ import {
   getPassword,
   mapUserConfigToCreateSchema,
   mapUserPolicyConfigToSchema,
+  mapUserConfigToConfiguration,
 } from "../../src/mappers/users";
 import {
   type UserConfig,
@@ -14,6 +15,7 @@ import {
 import {
   type CreateUserByNameSchema,
   type UserPolicySchema,
+  type UserConfigurationSchema,
 } from "../../src/types/schema/users";
 
 describe("mappers/users", () => {
@@ -365,6 +367,37 @@ describe("mappers/users", () => {
       expect(result).toEqual({
         LoginAttemptsBeforeLockout: 0,
       });
+    });
+  });
+
+  describe("mapUserConfigToConfiguration", () => {
+    it("should map configuration fields when provided", () => {
+      const config: UserConfig = {
+        name: "user",
+        password: "pass",
+        displayMissingEpisodes: true,
+        subtitleLanguagePreference: "eng",
+      };
+
+      const result: Partial<UserConfigurationSchema> =
+        mapUserConfigToConfiguration(config);
+
+      expect(result).toEqual({
+        DisplayMissingEpisodes: true,
+        SubtitleLanguagePreference: "eng",
+      });
+    });
+
+    it("should return empty object when configuration fields are undefined", () => {
+      const config: UserConfig = {
+        name: "user",
+        password: "pass",
+      };
+
+      const result: Partial<UserConfigurationSchema> =
+        mapUserConfigToConfiguration(config);
+
+      expect(result).toEqual({});
     });
   });
 });

--- a/tests/mappers/users.spec.ts
+++ b/tests/mappers/users.spec.ts
@@ -377,6 +377,7 @@ describe("mappers/users", () => {
         password: "pass",
         displayMissingEpisodes: true,
         subtitleLanguagePreference: "eng",
+        maxActiveSessions: 5,
       };
 
       const result: Partial<UserConfigurationSchema> =
@@ -385,6 +386,7 @@ describe("mappers/users", () => {
       expect(result).toEqual({
         DisplayMissingEpisodes: true,
         SubtitleLanguagePreference: "eng",
+        MaxActiveSessions: 5,
       });
     });
 

--- a/tests/mappers/users.spec.ts
+++ b/tests/mappers/users.spec.ts
@@ -251,6 +251,7 @@ describe("mappers/users", () => {
       const config: UserPolicyConfig = {
         isAdministrator: true,
         loginAttemptsBeforeLockout: 5,
+        maxActiveSessions: 2,
         enableAllFolders: true,
         enableCollectionManagement: false,
       };
@@ -263,6 +264,7 @@ describe("mappers/users", () => {
       expect(result).toEqual({
         IsAdministrator: true,
         LoginAttemptsBeforeLockout: 5,
+        MaxActiveSessions: 2,
         EnableAllFolders: true,
         EnableCollectionManagement: false,
       });
@@ -285,6 +287,10 @@ describe("mappers/users", () => {
         {
           config: { loginAttemptsBeforeLockout: 10 },
           expected: { LoginAttemptsBeforeLockout: 10 },
+        },
+        {
+          config: { maxActiveSessions: 4 },
+          expected: { MaxActiveSessions: 4 },
         },
       ];
 
@@ -439,7 +445,6 @@ describe("mappers/users", () => {
         password: "pass",
         displayMissingEpisodes: true,
         subtitleLanguagePreference: "eng",
-        maxActiveSessions: 5,
       };
 
       const result: Partial<UserConfigurationSchema> =
@@ -448,7 +453,6 @@ describe("mappers/users", () => {
       expect(result).toEqual({
         DisplayMissingEpisodes: true,
         SubtitleLanguagePreference: "eng",
-        MaxActiveSessions: 5,
       });
     });
 

--- a/tests/types/config/library.spec.ts
+++ b/tests/types/config/library.spec.ts
@@ -30,6 +30,78 @@ describe("types/config/library", () => {
       expect(parsed.libraryOptions.pathInfos[0].path).toBe("/data/movies");
     });
 
+    it("should accept valid typeOptions definitions", () => {
+      const config: z.input<typeof VirtualFolderConfigType> = {
+        name: "Movies",
+        collectionType: "movies",
+        libraryOptions: {
+          pathInfos: [{ path: "/data/movies" }],
+          typeOptions: [
+            {
+              type: "Movie",
+              metadataFetchers: ["TheMovieDB"],
+              imageFetchers: ["TheMovieDB"],
+            },
+          ],
+        },
+      };
+
+      const parsed: VirtualFolderConfig = VirtualFolderConfigType.parse(config);
+      expect(parsed.libraryOptions.typeOptions).toHaveLength(1);
+      expect(parsed.libraryOptions.typeOptions?.[0].type).toBe("Movie");
+      expect(parsed.libraryOptions.typeOptions?.[0].metadataFetchers).toEqual([
+        "TheMovieDB",
+      ]);
+      expect(parsed.libraryOptions.typeOptions?.[0].imageFetchers).toEqual([
+        "TheMovieDB",
+      ]);
+    });
+
+    it("should allow empty fetcher arrays in typeOptions", () => {
+      const config: z.input<typeof VirtualFolderConfigType> = {
+        name: "Movies",
+        collectionType: "movies",
+        libraryOptions: {
+          pathInfos: [{ path: "/data/movies" }],
+          typeOptions: [
+            {
+              type: "Movie",
+              metadataFetchers: [],
+              imageFetchers: [],
+            },
+          ],
+        },
+      };
+
+      expect(() => VirtualFolderConfigType.parse(config)).not.toThrow();
+      const parsed: VirtualFolderConfig = VirtualFolderConfigType.parse(config);
+      expect(parsed.libraryOptions.typeOptions?.[0].metadataFetchers).toEqual(
+        [],
+      );
+      expect(parsed.libraryOptions.typeOptions?.[0].imageFetchers).toEqual([]);
+    });
+
+    it("should accept null fetcher order arrays in typeOptions", () => {
+      const config: z.input<typeof VirtualFolderConfigType> = {
+        name: "Movies",
+        collectionType: "movies",
+        libraryOptions: {
+          pathInfos: [{ path: "/data/movies" }],
+          typeOptions: [
+            {
+              type: "Movie",
+              metadataFetchers: ["TheMovieDB"],
+              metadataFetcherOrder: null,
+              imageFetchers: ["TheMovieDB"],
+              imageFetcherOrder: null,
+            },
+          ],
+        },
+      };
+
+      expect(() => VirtualFolderConfigType.parse(config)).not.toThrow();
+    });
+
     it("should accept all valid collection types", () => {
       const types: readonly [
         "movies",
@@ -115,6 +187,37 @@ describe("types/config/library", () => {
       expect(() => VirtualFolderConfigType.parse(config)).toThrow(/too_small/);
     });
 
+    it("should accept empty typeOptions array", () => {
+      const config: z.input<typeof VirtualFolderConfigType> = {
+        name: "Test",
+        collectionType: "movies",
+        libraryOptions: {
+          pathInfos: [{ path: "/test" }],
+          typeOptions: [],
+        },
+      };
+
+      expect(() => VirtualFolderConfigType.parse(config)).not.toThrow();
+    });
+
+    it("should reject invalid typeOptions entries", () => {
+      const config: z.input<typeof VirtualFolderConfigType> = {
+        name: "Test",
+        collectionType: "movies",
+        libraryOptions: {
+          pathInfos: [{ path: "/test" }],
+          typeOptions: [
+            // @ts-expect-error metadataFetchers missing for test
+            { type: "Movie", imageFetchers: ["TheMovieDB"] },
+          ],
+        },
+      };
+
+      expect(() => VirtualFolderConfigType.parse(config)).toThrow(
+        /Invalid input/,
+      );
+    });
+
     it("should reject missing required fields", () => {
       expect(() => VirtualFolderConfigType.parse({})).toThrow(/Invalid input/);
       expect(() => VirtualFolderConfigType.parse({ name: "Test" })).toThrow(
@@ -166,6 +269,13 @@ describe("types/config/library", () => {
         collectionType: "movies",
         libraryOptions: {
           pathInfos: [{ path: "/data/movies" }],
+          typeOptions: [
+            {
+              type: "Movie",
+              metadataFetchers: ["TheMovieDB"],
+              imageFetchers: ["TheMovieDB"],
+            },
+          ],
         },
       };
 
@@ -175,6 +285,13 @@ describe("types/config/library", () => {
       );
       expect(Array.isArray(parsed.libraryOptions.pathInfos)).toBe(true);
       expect(typeof parsed.libraryOptions.pathInfos[0].path).toBe("string");
+      expect(parsed.libraryOptions.typeOptions?.[0].type).toBe("Movie");
+      expect(parsed.libraryOptions.typeOptions?.[0].metadataFetchers[0]).toBe(
+        "TheMovieDB",
+      );
+      expect(parsed.libraryOptions.typeOptions?.[0].imageFetchers[0]).toBe(
+        "TheMovieDB",
+      );
     });
   });
 
@@ -188,6 +305,13 @@ describe("types/config/library", () => {
             collectionType: "movies",
             libraryOptions: {
               pathInfos: [{ path: "/data/movies" }],
+              typeOptions: [
+                {
+                  type: "Movie",
+                  metadataFetchers: ["TheMovieDB"],
+                  imageFetchers: ["TheMovieDB"],
+                },
+              ],
             },
           },
           {

--- a/tests/types/config/library.spec.ts
+++ b/tests/types/config/library.spec.ts
@@ -43,6 +43,18 @@ describe("types/config/library", () => {
               imageFetchers: ["TheMovieDB"],
             },
           ],
+          automaticallyAddToCollection: true,
+          enableChapterImageExtraction: true,
+          extractChapterImagesDuringLibraryScan: true,
+          extractTrickplayImagesDuringLibraryScan: true,
+          enableEmbeddedEpisodeInfos: true,
+          enableEmbeddedExtraTitles: true,
+          enableTrickplayImageExtraction: true,
+          saveTrickplayWithMedia: true,
+          metadataSavers: ["Nfo"],
+          saveLocalMetadata: true,
+          automaticRefreshIntervalDays: 14,
+          enableRealtimeMonitor: true,
         },
       };
 
@@ -55,6 +67,22 @@ describe("types/config/library", () => {
       expect(parsed.libraryOptions.typeOptions?.[0].imageFetchers).toEqual([
         "TheMovieDB",
       ]);
+      expect(parsed.libraryOptions.automaticallyAddToCollection).toBe(true);
+      expect(parsed.libraryOptions.enableChapterImageExtraction).toBe(true);
+      expect(parsed.libraryOptions.extractChapterImagesDuringLibraryScan).toBe(
+        true,
+      );
+      expect(
+        parsed.libraryOptions.extractTrickplayImagesDuringLibraryScan,
+      ).toBe(true);
+      expect(parsed.libraryOptions.enableEmbeddedEpisodeInfos).toBe(true);
+      expect(parsed.libraryOptions.enableEmbeddedExtraTitles).toBe(true);
+      expect(parsed.libraryOptions.enableTrickplayImageExtraction).toBe(true);
+      expect(parsed.libraryOptions.saveTrickplayWithMedia).toBe(true);
+      expect(parsed.libraryOptions.metadataSavers).toEqual(["Nfo"]);
+      expect(parsed.libraryOptions.saveLocalMetadata).toBe(true);
+      expect(parsed.libraryOptions.automaticRefreshIntervalDays).toBe(14);
+      expect(parsed.libraryOptions.enableRealtimeMonitor).toBe(true);
     });
 
     it("should allow empty fetcher arrays in typeOptions", () => {
@@ -276,6 +304,17 @@ describe("types/config/library", () => {
               imageFetchers: ["TheMovieDB"],
             },
           ],
+          automaticallyAddToCollection: true,
+          enableChapterImageExtraction: true,
+          extractChapterImagesDuringLibraryScan: true,
+          extractTrickplayImagesDuringLibraryScan: true,
+          enableEmbeddedEpisodeInfos: true,
+          enableTrickplayImageExtraction: true,
+          saveTrickplayWithMedia: true,
+          metadataSavers: ["Nfo"],
+          saveLocalMetadata: true,
+          automaticRefreshIntervalDays: 14,
+          enableRealtimeMonitor: true,
         },
       };
 
@@ -292,6 +331,21 @@ describe("types/config/library", () => {
       expect(parsed.libraryOptions.typeOptions?.[0].imageFetchers[0]).toBe(
         "TheMovieDB",
       );
+      expect(parsed.libraryOptions.automaticallyAddToCollection).toBe(true);
+      expect(parsed.libraryOptions.enableChapterImageExtraction).toBe(true);
+      expect(parsed.libraryOptions.extractChapterImagesDuringLibraryScan).toBe(
+        true,
+      );
+      expect(
+        parsed.libraryOptions.extractTrickplayImagesDuringLibraryScan,
+      ).toBe(true);
+      expect(parsed.libraryOptions.enableEmbeddedEpisodeInfos).toBe(true);
+      expect(parsed.libraryOptions.enableTrickplayImageExtraction).toBe(true);
+      expect(parsed.libraryOptions.saveTrickplayWithMedia).toBe(true);
+      expect(parsed.libraryOptions.metadataSavers?.[0]).toBe("Nfo");
+      expect(parsed.libraryOptions.saveLocalMetadata).toBe(true);
+      expect(parsed.libraryOptions.automaticRefreshIntervalDays).toBe(14);
+      expect(parsed.libraryOptions.enableRealtimeMonitor).toBe(true);
     });
   });
 

--- a/tests/types/config/system.spec.ts
+++ b/tests/types/config/system.spec.ts
@@ -232,3 +232,18 @@ describe("TrickplayOptionsConfig", () => {
     expect(result.success).toBe(false);
   });
 });
+
+describe("SystemConfigType", () => {
+  it("should allow serverName", () => {
+    const config: z.input<typeof SystemConfigType> = {
+      serverName: "MyServer",
+    };
+
+    const result = SystemConfigType.safeParse(config);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.serverName).toBe("MyServer");
+    }
+  });
+});

--- a/tests/types/config/system.spec.ts
+++ b/tests/types/config/system.spec.ts
@@ -203,6 +203,7 @@ describe("TrickplayOptionsConfig", () => {
     const validConfig: z.input<typeof TrickplayOptionsConfigType> = {
       enableHwAcceleration: false,
       enableHwEncoding: true,
+      processThreads: 4,
     };
 
     // Act

--- a/tests/types/config/users.spec.ts
+++ b/tests/types/config/users.spec.ts
@@ -382,6 +382,7 @@ describe("UserPolicyConfig", () => {
       loginAttemptsBeforeLockout: 5,
       enableAllFolders: true,
       enableCollectionManagement: false,
+      maxActiveSessions: 2,
     };
 
     // Act
@@ -519,6 +520,7 @@ describe("UserConfig with policy", () => {
         enableAllFolders: false,
         enableCollectionManagement: true,
       },
+      maxActiveSessions: 2,
     };
 
     // Act

--- a/tests/types/config/users.spec.ts
+++ b/tests/types/config/users.spec.ts
@@ -382,7 +382,7 @@ describe("UserPolicyConfig", () => {
       loginAttemptsBeforeLockout: 5,
       enableAllFolders: true,
       enableCollectionManagement: false,
-      maxActiveSessions: 2,
+      enabledLibraries: ["Movies", "TV Shows"],
     };
 
     // Act
@@ -488,6 +488,31 @@ describe("UserPolicyConfig", () => {
     }
   });
 
+  it("should reject empty enabledLibraries entries", () => {
+    const invalidConfig: z.input<typeof UserPolicyConfigType> = {
+      enabledLibraries: [""],
+    };
+
+    const result: ZodSafeParseResult<UserPolicyConfig> =
+      UserPolicyConfigType.safeParse(invalidConfig);
+
+    expect(result.success).toBe(false);
+  });
+
+  it("should allow empty enabledLibraries array", () => {
+    const validConfig: z.input<typeof UserPolicyConfigType> = {
+      enabledLibraries: [],
+    };
+
+    const result: ZodSafeParseResult<UserPolicyConfig> =
+      UserPolicyConfigType.safeParse(validConfig);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual(validConfig);
+    }
+  });
+
   it("should reject non-boolean policy fields", () => {
     // Arrange
     const invalidConfigs: Array<z.input<typeof UserPolicyConfigType>> = [
@@ -519,6 +544,7 @@ describe("UserConfig with policy", () => {
         loginAttemptsBeforeLockout: 3,
         enableAllFolders: false,
         enableCollectionManagement: true,
+        enabledLibraries: ["Movies"],
       },
       maxActiveSessions: 2,
     };

--- a/tests/types/config/users.spec.ts
+++ b/tests/types/config/users.spec.ts
@@ -380,6 +380,8 @@ describe("UserPolicyConfig", () => {
     const validConfig: z.input<typeof UserPolicyConfigType> = {
       isAdministrator: true,
       loginAttemptsBeforeLockout: 5,
+      enableAllFolders: true,
+      enableCollectionManagement: false,
     };
 
     // Act
@@ -514,6 +516,8 @@ describe("UserConfig with policy", () => {
       policy: {
         isAdministrator: true,
         loginAttemptsBeforeLockout: 3,
+        enableAllFolders: false,
+        enableCollectionManagement: true,
       },
     };
 


### PR DESCRIPTION
- **Support typeOptions for libraries**
- **Support processThreads for trickplay**
- **Support system.serverName**
- **Support user policy.enable{AllFolders,CollectionManagement}**
- **Support user displayMissingEpisodes and subtitleLanguagePreference**
- **Support user maxActiveSessions**
- **Support more library settings**
- **Support policy.enabledLibraries**

This series is a result of me attempting to migrate from declarative-jellyfin NixOS module to Jellarr. Several key features turned out missing so I implemented them.

What the PR does:
- Fixes updates for libraries (I believe it should resolve #48 since I also saw duplicate libraries created during my testing before the series);
- Adds per-user configuration for enabled libraries (I enable different libraries for different users);
- A number of settings for libraries and users that I personally use (like putting NFOs in media directories; configuring different metadata and image fetchers for different libraries; configuring trickplay threads and server name; etc.)

Note that I don't know TypeScript and used Codex (GPT) to help me with uplifting it. I checked the result visually, added missing tests, tested the series on a test jellyfin VM. I have not tested the series on my "prod" jellyfin server that still uses declarative-jellyfin (I will test it there when I have another few hours to spare...)

Obviously, I don't want to maintain a 1000LOC+ fork in my repo. :) Let me know if you are interested in accepting the series in whole or in part, and what's missing to let it in.

Thanks!