### PR TITLE
Extend networking, API keys, library purge, and expanded config fields

### DIFF
--- a/src/api/jellyfin.types.ts
+++ b/src/api/jellyfin.types.ts
@@ -4,6 +4,7 @@ import type {
   VirtualFolderInfoSchema,
   AddVirtualFolderDtoSchema,
   CollectionTypeSchema,
+  LibraryOptionsSchema,
 } from "../types/schema/library";
 import type { BrandingOptionsDtoSchema } from "../types/schema/branding-options";
 import type {
@@ -15,6 +16,8 @@ import {
   type PluginInfoSchema,
   type BasePluginConfigurationSchema,
 } from "../types/schema/plugins";
+import type { NetworkConfigurationSchema } from "../types/schema/networking";
+import type { AuthenticationInfoSchema } from "../types/schema/api-keys";
 
 export interface ApiResponse<T = unknown> {
   data?: T;
@@ -29,6 +32,7 @@ export type GetEncodingConfigurationResponse = ApiResponse;
 export type PostEncodingConfigurationResponse = ApiResponse<void>;
 export type GetVirtualFoldersResponse = ApiResponse<VirtualFolderInfoSchema[]>;
 export type PostVirtualFolderResponse = ApiResponse<void>;
+export type PostLibraryOptionsResponse = ApiResponse<void>;
 export type GetBrandingConfigurationResponse = ApiResponse;
 export type PostBrandingConfigurationResponse = ApiResponse<void>;
 export type GetUsersResponse = ApiResponse<UserDtoSchema[]>;
@@ -40,6 +44,14 @@ export type PostInstallPackageResponse = ApiResponse<void>;
 export type GetPluginConfigurationResponse =
   ApiResponse<BasePluginConfigurationSchema>;
 export type PostPluginConfigurationResponse = ApiResponse<void>;
+export type GetNetworkingConfigurationResponse = ApiResponse;
+export type PostNetworkingConfigurationResponse = ApiResponse<void>;
+export type GetApiKeysResponse = ApiResponse<{
+  Items?: AuthenticationInfoSchema[];
+}>;
+export type PostApiKeyResponse = ApiResponse<void>;
+export type DeleteApiKeyResponse = ApiResponse<void>;
+export type DeleteVirtualFolderResponse = ApiResponse<void>;
 
 export interface JellyfinClient {
   getSystemConfiguration(): Promise<ServerConfigurationSchema>;
@@ -55,6 +67,10 @@ export interface JellyfinClient {
     name: string,
     collectionType: CollectionTypeSchema | undefined,
     body: AddVirtualFolderDtoSchema,
+  ): Promise<void>;
+  updateLibraryOptions(
+    id: string,
+    libraryOptions: LibraryOptionsSchema,
   ): Promise<void>;
   getBrandingConfiguration(): Promise<BrandingOptionsDtoSchema>;
   updateBrandingConfiguration(
@@ -73,4 +89,11 @@ export interface JellyfinClient {
     pluginId: string,
     body: BasePluginConfigurationSchema,
   ): Promise<void>;
+  getNetworkingConfiguration(): Promise<NetworkConfigurationSchema>;
+  updateNetworkingConfiguration(
+    body: Partial<NetworkConfigurationSchema>,
+  ): Promise<void>;
+  removeVirtualFolder(name: string): Promise<void>;
+  getApiKeys(): Promise<AuthenticationInfoSchema[]>;
+  createApiKey(appName: string): Promise<void>;
 }

--- a/src/api/jellyfin_client.ts
+++ b/src/api/jellyfin_client.ts
@@ -4,6 +4,7 @@ import type {
   VirtualFolderInfoSchema,
   AddVirtualFolderDtoSchema,
   CollectionTypeSchema,
+  LibraryOptionsSchema,
 } from "../types/schema/library";
 import type { BrandingOptionsDtoSchema } from "../types/schema/branding-options";
 import type {
@@ -19,6 +20,7 @@ import type {
   PostEncodingConfigurationResponse,
   GetVirtualFoldersResponse,
   PostVirtualFolderResponse,
+  PostLibraryOptionsResponse,
   GetBrandingConfigurationResponse,
   PostBrandingConfigurationResponse,
   GetUsersResponse,
@@ -29,6 +31,11 @@ import type {
   PostInstallPackageResponse,
   GetPluginConfigurationResponse,
   PostPluginConfigurationResponse,
+  GetNetworkingConfigurationResponse,
+  PostNetworkingConfigurationResponse,
+  GetApiKeysResponse,
+  PostApiKeyResponse,
+  DeleteVirtualFolderResponse,
 } from "./jellyfin.types";
 import { makeClient } from "./client";
 import type { paths } from "../../generated/schema";
@@ -37,6 +44,8 @@ import {
   type PluginInfoSchema,
   type BasePluginConfigurationSchema,
 } from "../types/schema/plugins";
+import type { NetworkConfigurationSchema } from "../types/schema/networking";
+import type { AuthenticationInfoSchema } from "../types/schema/api-keys";
 
 export function createJellyfinClient(
   baseUrl: string,
@@ -150,6 +159,48 @@ export function createJellyfinClient(
       if (res.error) {
         throw new Error(
           `POST /Library/VirtualFolders failed: ${res.response.status.toString()}`,
+        );
+      }
+    },
+
+    async removeVirtualFolder(name: string): Promise<void> {
+      const res: DeleteVirtualFolderResponse = await client.DELETE(
+        "/Library/VirtualFolders",
+        {
+          params: {
+            query: {
+              name,
+              refreshLibrary: true,
+            },
+          },
+        },
+      );
+
+      if (res.error) {
+        throw new Error(
+          `DELETE /Library/VirtualFolders failed: ${res.response.status.toString()}`,
+        );
+      }
+    },
+
+    async updateLibraryOptions(
+      id: string,
+      libraryOptions: LibraryOptionsSchema,
+    ): Promise<void> {
+      const res: PostLibraryOptionsResponse = await client.POST(
+        "/Library/VirtualFolders/LibraryOptions",
+        {
+          body: {
+            Id: id,
+            LibraryOptions: libraryOptions,
+          },
+          headers: { "content-type": "application/json" },
+        },
+      );
+
+      if (res.error) {
+        throw new Error(
+          `POST /Library/VirtualFolders/LibraryOptions failed: ${res.response.status.toString()}`,
         );
       }
     },
@@ -300,6 +351,68 @@ export function createJellyfinClient(
       if (res.error) {
         throw new Error(
           `POST /Plugins/${pluginId}/Configuration failed: ${res.response.status.toString()}`,
+        );
+      }
+    },
+
+    async getNetworkingConfiguration(): Promise<NetworkConfigurationSchema> {
+      const res: GetNetworkingConfigurationResponse = await client.GET(
+        "/System/Configuration/{key}",
+        {
+          params: { path: { key: "network" } },
+        },
+      );
+
+      if (res.error) {
+        throw new Error(
+          `GET /System/Configuration/network failed: ${res.response.status.toString()}`,
+        );
+      }
+
+      return res.data as NetworkConfigurationSchema;
+    },
+
+    async updateNetworkingConfiguration(
+      body: Partial<NetworkConfigurationSchema>,
+    ): Promise<void> {
+      const res: PostNetworkingConfigurationResponse = await client.POST(
+        "/System/Configuration/{key}",
+        {
+          params: { path: { key: "network" } },
+          body,
+          headers: { "content-type": "application/json" },
+        },
+      );
+
+      if (res.error) {
+        throw new Error(
+          `POST /System/Configuration/network failed: ${res.response.status.toString()}`,
+        );
+      }
+    },
+
+    async getApiKeys(): Promise<AuthenticationInfoSchema[]> {
+      const res: GetApiKeysResponse = await client.GET("/Auth/Keys");
+
+      if (res.error) {
+        throw new Error(
+          `GET /Auth/Keys failed: ${res.response.status.toString()}`,
+        );
+      }
+
+      return (
+        (res.data as { Items?: AuthenticationInfoSchema[] })?.Items ?? []
+      );
+    },
+
+    async createApiKey(appName: string): Promise<void> {
+      const res: PostApiKeyResponse = await client.POST("/Auth/Keys", {
+        params: { query: { app: appName } },
+      });
+
+      if (res.error) {
+        throw new Error(
+          `POST /Auth/Keys failed: ${res.response.status.toString()}`,
         );
       }
     },

--- a/src/apply/api-keys.ts
+++ b/src/apply/api-keys.ts
@@ -1,0 +1,32 @@
+import { logger } from "../lib/logger";
+import type { JellyfinClient } from "../api/jellyfin.types";
+import type { ApiKeyConfig, ApiKeyConfigList } from "../types/config/api-keys";
+import type { AuthenticationInfoSchema } from "../types/schema/api-keys";
+
+export function calculateApiKeysToCreate(
+  current: AuthenticationInfoSchema[],
+  desired: ApiKeyConfigList,
+): ApiKeyConfig[] | undefined {
+  const existingNames = new Set(
+    current.map((key: AuthenticationInfoSchema) => key.AppName),
+  );
+
+  const toCreate = desired.filter(
+    (key: ApiKeyConfig) => !existingNames.has(key.name),
+  );
+
+  return toCreate.length > 0 ? toCreate : undefined;
+}
+
+export async function createApiKeys(
+  client: JellyfinClient,
+  keys: ApiKeyConfig[] | undefined,
+): Promise<void> {
+  if (!keys) return;
+
+  for (const key of keys) {
+    logger.info(`Creating API key: ${key.name}`);
+    await client.createApiKey(key.name);
+    logger.info(`✓ Created API key: ${key.name}`);
+  }
+}

--- a/src/apply/library.ts
+++ b/src/apply/library.ts
@@ -6,10 +6,12 @@ import type {
   VirtualFolderInfoSchema,
   CollectionTypeSchema,
   AddVirtualFolderDtoSchema,
+  LibraryOptionsSchema,
 } from "../types/schema/library";
 import {
   mapVirtualFolderConfigToSchema,
   mapVirtualFolderInfoSchemaToAddVirtualFolderDtoSchema,
+  mapLibraryOptionsConfigToSchema,
 } from "../mappers/library";
 import { applyChangeset, diff, type IChange } from "json-diff-ts";
 
@@ -21,27 +23,83 @@ export function calculateLibraryDiff(
     return undefined;
   }
 
-  const next: VirtualFolderInfoSchema[] = desired.map(
-    mapVirtualFolderConfigToSchema,
+  const currentNames: Set<string> = new Set(
+    current
+      .map((f: VirtualFolderInfoSchema) => f.Name)
+      .filter((n): n is string => n !== undefined),
   );
 
-  const patch: IChange[] = new ChangeSetBuilder(
-    diff(current, next, {
-      embeddedObjKeys: { ".": "Name" },
-      treatTypeChangeAsReplace: false,
-    }),
-  )
-    .atomize()
-    .withoutRemoves()
-    .withoutUpdates()
-    .toArray();
+  const toCreate: VirtualFolderInfoSchema[] = desired
+    .filter(
+      (d: VirtualFolderConfig) => !currentNames.has(d.name),
+    )
+    .map(mapVirtualFolderConfigToSchema);
 
-  if (patch.length !== 0) {
-    logger.info(JSON.stringify(patch));
-    return applyChangeset([], patch) as VirtualFolderInfoSchema[];
+  if (toCreate.length > 0) {
+    return toCreate;
   }
 
   return undefined;
+}
+
+export interface LibraryOptionsUpdate {
+  id: string;
+  name: string;
+  libraryOptions: LibraryOptionsSchema;
+}
+
+export function calculateLibraryOptionsDiff(
+  current: VirtualFolderInfoSchema[],
+  desired: VirtualFolderConfig[],
+): LibraryOptionsUpdate[] | undefined {
+  const updates: LibraryOptionsUpdate[] = [];
+
+  for (const desiredFolder of desired) {
+    const currentFolder = current.find(
+      (f: VirtualFolderInfoSchema) => f.Name === desiredFolder.name,
+    );
+    if (!currentFolder?.ItemId || !currentFolder.LibraryOptions) continue;
+
+    const desiredOptions: LibraryOptionsSchema =
+      mapLibraryOptionsConfigToSchema(desiredFolder.libraryOptions);
+
+    const patch: IChange[] = new ChangeSetBuilder(
+      diff(currentFolder.LibraryOptions, desiredOptions, {
+        treatTypeChangeAsReplace: false,
+      }),
+    )
+      .withoutRemoves()
+      .toArray();
+
+    if (patch.length !== 0) {
+      logger.info(
+        `Library options diff for "${desiredFolder.name}": ${JSON.stringify(patch)}`,
+      );
+      const updated = applyChangeset(
+        currentFolder.LibraryOptions,
+        patch,
+      ) as LibraryOptionsSchema;
+      updates.push({
+        id: currentFolder.ItemId,
+        name: desiredFolder.name,
+        libraryOptions: updated,
+      });
+    }
+  }
+
+  return updates.length > 0 ? updates : undefined;
+}
+
+export async function purgeLibraries(
+  client: JellyfinClient,
+  current: VirtualFolderInfoSchema[],
+): Promise<void> {
+  for (const folder of current) {
+    const name: string = folder.Name as string;
+    logger.info(`Removing virtual folder: ${name}`);
+    await client.removeVirtualFolder(name);
+    logger.info(`✓ Removed virtual folder: ${name}`);
+  }
 }
 
 export async function applyLibrary(
@@ -64,5 +122,18 @@ export async function applyLibrary(
     await client.addVirtualFolder(name, collectionType, addVirtualFolderDto);
 
     logger.info(`✓ Created virtual folder: ${name} (${collectionType})`);
+  }
+}
+
+export async function applyLibraryOptions(
+  client: JellyfinClient,
+  updates: LibraryOptionsUpdate[] | undefined,
+): Promise<void> {
+  if (!updates) return;
+
+  for (const update of updates) {
+    logger.info(`Updating library options for: ${update.name}`);
+    await client.updateLibraryOptions(update.id, update.libraryOptions);
+    logger.info(`✓ Updated library options for: ${update.name}`);
   }
 }

--- a/src/apply/networking.ts
+++ b/src/apply/networking.ts
@@ -1,0 +1,37 @@
+import { logger } from "../lib/logger";
+import { ChangeSetBuilder } from "../lib/changeset";
+import type { JellyfinClient } from "../api/jellyfin.types";
+import { mapNetworkingConfigToSchema } from "../mappers/networking";
+import type { NetworkingConfig } from "../types/config/networking";
+import type { NetworkConfigurationSchema } from "../types/schema/networking";
+import { diff, applyChangeset, type IChange } from "json-diff-ts";
+
+export function calculateNetworkingDiff(
+  current: NetworkConfigurationSchema,
+  desired: NetworkingConfig,
+): NetworkConfigurationSchema | undefined {
+  const next: Partial<NetworkConfigurationSchema> =
+    mapNetworkingConfigToSchema(desired);
+
+  const patch: IChange[] = new ChangeSetBuilder(
+    diff(current, next, { treatTypeChangeAsReplace: false }),
+  )
+    .withoutRemoves()
+    .toArray();
+
+  if (patch.length !== 0) {
+    logger.info(JSON.stringify(patch));
+    return applyChangeset(current, patch) as NetworkConfigurationSchema;
+  }
+
+  return undefined;
+}
+
+export async function applyNetworking(
+  client: JellyfinClient,
+  updatedSchema: NetworkConfigurationSchema | undefined,
+): Promise<void> {
+  if (!updatedSchema) return;
+
+  await client.updateNetworkingConfiguration(updatedSchema);
+}

--- a/src/apply/system.ts
+++ b/src/apply/system.ts
@@ -6,6 +6,30 @@ import { type SystemConfig } from "../types/config/system";
 import { type ServerConfigurationSchema } from "../types/schema/system";
 import { diff, applyChangeset, type IChange } from "json-diff-ts";
 
+const SIMPLE_KEYS: string[] = [
+  "ServerName",
+  "PreferredMetadataLanguage",
+  "MetadataCountryCode",
+  "UICulture",
+  "QuickConnectAvailable",
+  "EnableMetrics",
+  "EnableFolderView",
+  "EnableGroupingMoviesIntoCollections",
+  "EnableGroupingShowsIntoCollections",
+  "DisplaySpecialsWithinSeasons",
+  "EnableExternalContentInSuggestions",
+  "ActivityLogRetentionDays",
+  "LogFileRetentionDays",
+  "LibraryMonitorDelay",
+  "LibraryUpdateDuration",
+  "LibraryScanFanoutConcurrency",
+  "LibraryMetadataRefreshConcurrency",
+  "RemoteClientBitrateLimit",
+  "MinResumePct",
+  "MaxResumePct",
+  "MinResumeDurationSeconds",
+];
+
 export function calculateSystemDiff(
   current: ServerConfigurationSchema,
   desired: SystemConfig,
@@ -13,14 +37,17 @@ export function calculateSystemDiff(
   const next: ServerConfigurationSchema =
     mapSystemConfigurationConfigToSchema(desired);
 
+  const simpleDiff = diff(current, next, {
+    treatTypeChangeAsReplace: false,
+  });
+
+  const simpleChanges: IChange[] = SIMPLE_KEYS.flatMap(
+    (key: string) =>
+      new ChangeSetBuilder(simpleDiff).withKey(key).withoutRemoves().toArray(),
+  );
+
   const patch: IChange[] = new AtomicChangeSetBuilder([
-    ...new ChangeSetBuilder(
-      diff(current, next, { treatTypeChangeAsReplace: false }),
-    )
-      .withKey("EnableMetrics")
-      .withoutRemoves()
-      .atomize()
-      .toArray(),
+    ...new ChangeSetBuilder(simpleChanges).atomize().toArray(),
 
     ...new ChangeSetBuilder(
       diff(current, next, {
@@ -40,6 +67,39 @@ export function calculateSystemDiff(
       .withoutRemoves()
       .atomize()
       .withoutRemoves()
+      .toArray(),
+
+    ...new ChangeSetBuilder(
+      diff(current, next, {
+        embeddedObjKeys: { SortReplaceCharacters: "$value" },
+        treatTypeChangeAsReplace: false,
+      }),
+    )
+      .withKey("SortReplaceCharacters")
+      .withoutRemoves()
+      .atomize()
+      .toArray(),
+
+    ...new ChangeSetBuilder(
+      diff(current, next, {
+        embeddedObjKeys: { SortRemoveCharacters: "$value" },
+        treatTypeChangeAsReplace: false,
+      }),
+    )
+      .withKey("SortRemoveCharacters")
+      .withoutRemoves()
+      .atomize()
+      .toArray(),
+
+    ...new ChangeSetBuilder(
+      diff(current, next, {
+        embeddedObjKeys: { SortRemoveWords: "$value" },
+        treatTypeChangeAsReplace: false,
+      }),
+    )
+      .withKey("SortRemoveWords")
+      .withoutRemoves()
+      .atomize()
       .toArray(),
   ])
     .unatomize()

--- a/src/dump/index.ts
+++ b/src/dump/index.ts
@@ -8,6 +8,8 @@ import type { EncodingOptionsSchema } from "../types/schema/encoding-options";
 import type {
   VirtualFolderInfoSchema,
   MediaPathInfoSchema,
+  LibraryOptionsSchema,
+  TypeOptionsSchema,
 } from "../types/schema/library";
 import type { BrandingOptionsDtoSchema } from "../types/schema/branding-options";
 import type { UserDtoSchema } from "../types/schema/users";
@@ -15,11 +17,76 @@ import type {
   PluginInfoSchema,
   BasePluginConfigurationSchema,
 } from "../types/schema/plugins";
+import type { NetworkConfigurationSchema } from "../types/schema/networking";
+import type { AuthenticationInfoSchema } from "../types/schema/api-keys";
 import * as yaml from "yaml";
 
 interface PluginWithConfig {
   name: string;
   configuration?: BasePluginConfigurationSchema;
+}
+
+function dumpLibraryOptions(opts: LibraryOptionsSchema | null | undefined) {
+  if (!opts) return { pathInfos: [] };
+  return {
+    pathInfos:
+      opts.PathInfos?.map((p: MediaPathInfoSchema) => ({
+        path: p.Path ?? "",
+      })) ?? [],
+    ...(opts.SaveLocalMetadata !== undefined && {
+      saveLocalMetadata: opts.SaveLocalMetadata,
+    }),
+    ...(opts.EnableRealtimeMonitor !== undefined && {
+      enableRealtimeMonitor: opts.EnableRealtimeMonitor,
+    }),
+    ...(opts.EnableAutomaticSeriesGrouping !== undefined && {
+      enableAutomaticSeriesGrouping: opts.EnableAutomaticSeriesGrouping,
+    }),
+    ...(opts.EnableEmbeddedTitles !== undefined && {
+      enableEmbeddedTitles: opts.EnableEmbeddedTitles,
+    }),
+    ...(opts.EnableEmbeddedEpisodeInfos !== undefined && {
+      enableEmbeddedEpisodeInfos: opts.EnableEmbeddedEpisodeInfos,
+    }),
+    ...(opts.EnableTrickplayImageExtraction !== undefined && {
+      enableTrickplayImageExtraction: opts.EnableTrickplayImageExtraction,
+    }),
+    ...(opts.EnableChapterImageExtraction !== undefined && {
+      enableChapterImageExtraction: opts.EnableChapterImageExtraction,
+    }),
+    ...(opts.SubtitleDownloadLanguages !== undefined && {
+      subtitleDownloadLanguages: opts.SubtitleDownloadLanguages,
+    }),
+    ...(opts.SkipSubtitlesIfEmbeddedSubtitlesPresent !== undefined && {
+      skipSubtitlesIfEmbeddedSubtitlesPresent:
+        opts.SkipSubtitlesIfEmbeddedSubtitlesPresent,
+    }),
+    ...(opts.SkipSubtitlesIfAudioTrackMatches !== undefined && {
+      skipSubtitlesIfAudioTrackMatches: opts.SkipSubtitlesIfAudioTrackMatches,
+    }),
+    ...(opts.MetadataSavers !== undefined && {
+      metadataSavers: opts.MetadataSavers,
+    }),
+    ...(opts.AutomaticallyAddToCollection !== undefined && {
+      enableCrossLibrarySeriesMerging: opts.AutomaticallyAddToCollection,
+    }),
+    ...(opts.TypeOptions &&
+      opts.TypeOptions.length > 0 && {
+        typeOptions: opts.TypeOptions.map((to: TypeOptionsSchema) => ({
+          type: to.Type ?? "",
+          ...(to.MetadataFetchers && {
+            metadataFetchers: to.MetadataFetchers,
+          }),
+          ...(to.MetadataFetcherOrder && {
+            metadataFetcherOrder: to.MetadataFetcherOrder,
+          }),
+          ...(to.ImageFetchers && { imageFetchers: to.ImageFetchers }),
+          ...(to.ImageFetcherOrder && {
+            imageFetcherOrder: to.ImageFetcherOrder,
+          }),
+        })),
+      }),
+  };
 }
 
 export async function runDump(baseUrl: string): Promise<void> {
@@ -39,6 +106,8 @@ export async function runDump(baseUrl: string): Promise<void> {
     brandingConfig,
     users,
     plugins,
+    networkingConfig,
+    apiKeys,
   ]: [
     ServerConfigurationSchema,
     EncodingOptionsSchema,
@@ -46,6 +115,8 @@ export async function runDump(baseUrl: string): Promise<void> {
     BrandingOptionsDtoSchema,
     UserDtoSchema[],
     PluginInfoSchema[],
+    NetworkConfigurationSchema,
+    AuthenticationInfoSchema[],
   ] = await Promise.all([
     client.getSystemConfiguration(),
     client.getEncodingConfiguration(),
@@ -53,30 +124,63 @@ export async function runDump(baseUrl: string): Promise<void> {
     client.getBrandingConfiguration(),
     client.getUsers(),
     client.getPlugins(),
+    client.getNetworkingConfiguration(),
+    client.getApiKeys(),
   ]);
 
   const pluginsWithConfig: PluginWithConfig[] = await Promise.all(
-    plugins.map(async (plugin: PluginInfoSchema): Promise<PluginWithConfig> => {
-      if (!plugin.Id) return { name: plugin.Name ?? "unknown" };
-      try {
-        const pluginConfig: BasePluginConfigurationSchema =
-          await client.getPluginConfiguration(plugin.Id);
-        return {
-          name: plugin.Name ?? "unknown",
-          configuration: pluginConfig,
-        };
-      } catch {
-        return { name: plugin.Name ?? "unknown" };
-      }
-    }),
+    plugins.map(
+      async (plugin: PluginInfoSchema): Promise<PluginWithConfig> => {
+        if (!plugin.Id) return { name: plugin.Name ?? "unknown" };
+        try {
+          const pluginConfig: BasePluginConfigurationSchema =
+            await client.getPluginConfiguration(plugin.Id);
+          return {
+            name: plugin.Name ?? "unknown",
+            configuration: pluginConfig,
+          };
+        } catch {
+          return { name: plugin.Name ?? "unknown" };
+        }
+      },
+    ),
   );
+
+  const trickplay = systemConfig.TrickplayOptions;
 
   const config: object = {
     version: 1,
     base_url: baseUrl,
 
     system: {
+      serverName: systemConfig.ServerName,
+      preferredMetadataLanguage: systemConfig.PreferredMetadataLanguage,
+      metadataCountryCode: systemConfig.MetadataCountryCode,
+      uiCulture: systemConfig.UICulture,
+      quickConnectAvailable: systemConfig.QuickConnectAvailable,
       enableMetrics: systemConfig.EnableMetrics,
+      enableFolderView: systemConfig.EnableFolderView,
+      enableGroupingMoviesIntoCollections:
+        systemConfig.EnableGroupingMoviesIntoCollections,
+      enableGroupingShowsIntoCollections:
+        systemConfig.EnableGroupingShowsIntoCollections,
+      displaySpecialsWithinSeasons: systemConfig.DisplaySpecialsWithinSeasons,
+      enableExternalContentInSuggestions:
+        systemConfig.EnableExternalContentInSuggestions,
+      activityLogRetentionDays: systemConfig.ActivityLogRetentionDays,
+      logFileRetentionDays: systemConfig.LogFileRetentionDays,
+      libraryMonitorDelay: systemConfig.LibraryMonitorDelay,
+      libraryUpdateDuration: systemConfig.LibraryUpdateDuration,
+      libraryScanFanoutConcurrency: systemConfig.LibraryScanFanoutConcurrency,
+      libraryMetadataRefreshConcurrency:
+        systemConfig.LibraryMetadataRefreshConcurrency,
+      remoteClientBitrateLimit: systemConfig.RemoteClientBitrateLimit,
+      minResumePct: systemConfig.MinResumePct,
+      maxResumePct: systemConfig.MaxResumePct,
+      minResumeDurationSeconds: systemConfig.MinResumeDurationSeconds,
+      sortReplaceCharacters: systemConfig.SortReplaceCharacters,
+      sortRemoveCharacters: systemConfig.SortRemoveCharacters,
+      sortRemoveWords: systemConfig.SortRemoveWords,
       pluginRepositories: systemConfig.PluginRepositories?.map(
         (repo: PluginRepositorySchema) => ({
           name: repo.Name ?? "",
@@ -85,13 +189,34 @@ export async function runDump(baseUrl: string): Promise<void> {
         }),
       ),
       trickplayOptions: {
-        enableHwAcceleration:
-          systemConfig.TrickplayOptions?.EnableHwAcceleration,
-        enableHwEncoding: systemConfig.TrickplayOptions?.EnableHwEncoding,
+        enableHwAcceleration: trickplay?.EnableHwAcceleration,
+        enableHwEncoding: trickplay?.EnableHwEncoding,
+        enableKeyFrameOnlyExtraction: trickplay?.EnableKeyFrameOnlyExtraction,
+        scanBehavior: trickplay?.ScanBehavior,
+        processPriority: trickplay?.ProcessPriority,
+        interval: trickplay?.Interval,
+        widthResolutions: trickplay?.WidthResolutions,
+        tileWidth: trickplay?.TileWidth,
+        tileHeight: trickplay?.TileHeight,
+        qscale: trickplay?.Qscale,
+        jpegQuality: trickplay?.JpegQuality,
+        processThreads: trickplay?.ProcessThreads,
       },
     },
 
     encoding: {
+      encodingThreadCount: encodingConfig.EncodingThreadCount,
+      transcodingTempPath: encodingConfig.TranscodingTempPath,
+      enableFallbackFont: encodingConfig.EnableFallbackFont,
+      fallbackFontPath: encodingConfig.FallbackFontPath,
+      enableAudioVbr: encodingConfig.EnableAudioVbr,
+      downMixAudioBoost: encodingConfig.DownMixAudioBoost,
+      downMixStereoAlgorithm: encodingConfig.DownMixStereoAlgorithm,
+      maxMuxingQueueSize: encodingConfig.MaxMuxingQueueSize,
+      enableThrottling: encodingConfig.EnableThrottling,
+      throttleDelaySeconds: encodingConfig.ThrottleDelaySeconds,
+      enableSegmentDeletion: encodingConfig.EnableSegmentDeletion,
+      segmentKeepSeconds: encodingConfig.SegmentKeepSeconds,
       enableHardwareEncoding: encodingConfig.EnableHardwareEncoding,
       hardwareAccelerationType: encodingConfig.HardwareAccelerationType,
       vaapiDevice: encodingConfig.VaapiDevice,
@@ -105,27 +230,64 @@ export async function runDump(baseUrl: string): Promise<void> {
         encodingConfig.EnableDecodingColorDepth10HevcRext,
       enableDecodingColorDepth12HevcRext:
         encodingConfig.EnableDecodingColorDepth12HevcRext,
+      enableEnhancedNvdecDecoder: encodingConfig.EnableEnhancedNvdecDecoder,
+      preferSystemNativeHwDecoder: encodingConfig.PreferSystemNativeHwDecoder,
       allowHevcEncoding: encodingConfig.AllowHevcEncoding,
       allowAv1Encoding: encodingConfig.AllowAv1Encoding,
+      enableSubtitleExtraction: encodingConfig.EnableSubtitleExtraction,
+      h264Crf: encodingConfig.H264Crf,
+      h265Crf: encodingConfig.H265Crf,
+      deinterlaceMethod: encodingConfig.DeinterlaceMethod,
+      deinterlaceDoubleRate: encodingConfig.DeinterlaceDoubleRate,
+      tonemapping: {
+        enabled: encodingConfig.EnableTonemapping,
+        algorithm: encodingConfig.TonemappingAlgorithm,
+        mode: encodingConfig.TonemappingMode,
+        range: encodingConfig.TonemappingRange,
+        desat: encodingConfig.TonemappingDesat,
+        peak: encodingConfig.TonemappingPeak,
+      },
     },
 
     library: {
-      virtualFolders: virtualFolders.map((folder: VirtualFolderInfoSchema) => ({
-        name: folder.Name ?? "",
-        collectionType: folder.CollectionType ?? "mixed",
-        libraryOptions: {
-          pathInfos:
-            folder.LibraryOptions?.PathInfos?.map((p: MediaPathInfoSchema) => ({
-              path: p.Path ?? "",
-            })) ?? [],
-        },
-      })),
+      virtualFolders: virtualFolders.map(
+        (folder: VirtualFolderInfoSchema) => ({
+          name: folder.Name ?? "",
+          collectionType: folder.CollectionType ?? "mixed",
+          libraryOptions: dumpLibraryOptions(folder.LibraryOptions),
+        }),
+      ),
     },
 
     branding: {
       loginDisclaimer: brandingConfig.LoginDisclaimer,
       customCss: brandingConfig.CustomCss,
       splashscreenEnabled: brandingConfig.SplashscreenEnabled,
+    },
+
+    networking: {
+      baseUrl: networkingConfig.BaseUrl,
+      enableHttps: networkingConfig.EnableHttps,
+      requireHttps: networkingConfig.RequireHttps,
+      internalHttpPort: networkingConfig.InternalHttpPort,
+      internalHttpsPort: networkingConfig.InternalHttpsPort,
+      publicHttpPort: networkingConfig.PublicHttpPort,
+      publicHttpsPort: networkingConfig.PublicHttpsPort,
+      enableRemoteAccess: networkingConfig.EnableRemoteAccess,
+      enableIPv4: networkingConfig.EnableIPv4,
+      enableIPv6: networkingConfig.EnableIPv6,
+      enableUPnP: networkingConfig.EnableUPnP,
+      knownProxies: networkingConfig.KnownProxies,
+      localNetworkSubnets: networkingConfig.LocalNetworkSubnets,
+      localNetworkAddresses: networkingConfig.LocalNetworkAddresses,
+      remoteIpFilter: networkingConfig.RemoteIPFilter,
+      isRemoteIpFilterBlacklist: networkingConfig.IsRemoteIPFilterBlacklist,
+      ignoreVirtualInterfaces: networkingConfig.IgnoreVirtualInterfaces,
+      virtualInterfaceNames: networkingConfig.VirtualInterfaceNames,
+      enablePublishedServerUriByRequest:
+        networkingConfig.EnablePublishedServerUriByRequest,
+      publishedServerUriBySubnet: networkingConfig.PublishedServerUriBySubnet,
+      corsHosts: systemConfig.CorsHosts,
     },
 
     users: users.map((user: UserDtoSchema) => ({
@@ -137,6 +299,10 @@ export async function runDump(baseUrl: string): Promise<void> {
     })),
 
     plugins: pluginsWithConfig,
+
+    api_keys: apiKeys.map((key: AuthenticationInfoSchema) => ({
+      name: key.AppName ?? "",
+    })),
   };
 
   console.log(yaml.stringify(config));

--- a/src/mappers/encoding-options.ts
+++ b/src/mappers/encoding-options.ts
@@ -1,10 +1,73 @@
-import { type EncodingOptionsConfig } from "../types/config/encoding-options";
+import {
+  type EncodingOptionsConfig,
+  type TonemappingConfig,
+} from "../types/config/encoding-options";
 import { type EncodingOptionsSchema } from "../types/schema/encoding-options";
+
+function mapTonemapping(
+  tm: TonemappingConfig,
+  out: Partial<EncodingOptionsSchema>,
+): void {
+  if (tm.enabled !== undefined) out.EnableTonemapping = tm.enabled;
+  if (tm.algorithm !== undefined) out.TonemappingAlgorithm = tm.algorithm;
+  if (tm.mode !== undefined) out.TonemappingMode = tm.mode;
+  if (tm.range !== undefined) out.TonemappingRange = tm.range;
+  if (tm.desat !== undefined) out.TonemappingDesat = tm.desat;
+  if (tm.peak !== undefined) out.TonemappingPeak = tm.peak;
+}
 
 export function mapEncodingOptionsConfigToSchema(
   desired: EncodingOptionsConfig,
 ): Partial<EncodingOptionsSchema> {
   const out: Partial<EncodingOptionsSchema> = {};
+
+  if (typeof desired.encodingThreadCount !== "undefined") {
+    out.EncodingThreadCount = desired.encodingThreadCount;
+  }
+
+  if (typeof desired.transcodingTempPath !== "undefined") {
+    out.TranscodingTempPath = desired.transcodingTempPath;
+  }
+
+  if (typeof desired.enableFallbackFont !== "undefined") {
+    out.EnableFallbackFont = desired.enableFallbackFont;
+  }
+
+  if (typeof desired.fallbackFontPath !== "undefined") {
+    out.FallbackFontPath = desired.fallbackFontPath;
+  }
+
+  if (typeof desired.enableAudioVbr !== "undefined") {
+    out.EnableAudioVbr = desired.enableAudioVbr;
+  }
+
+  if (typeof desired.downMixAudioBoost !== "undefined") {
+    out.DownMixAudioBoost = desired.downMixAudioBoost;
+  }
+
+  if (typeof desired.downMixStereoAlgorithm !== "undefined") {
+    out.DownMixStereoAlgorithm = desired.downMixStereoAlgorithm;
+  }
+
+  if (typeof desired.maxMuxingQueueSize !== "undefined") {
+    out.MaxMuxingQueueSize = desired.maxMuxingQueueSize;
+  }
+
+  if (typeof desired.enableThrottling !== "undefined") {
+    out.EnableThrottling = desired.enableThrottling;
+  }
+
+  if (typeof desired.throttleDelaySeconds !== "undefined") {
+    out.ThrottleDelaySeconds = desired.throttleDelaySeconds;
+  }
+
+  if (typeof desired.enableSegmentDeletion !== "undefined") {
+    out.EnableSegmentDeletion = desired.enableSegmentDeletion;
+  }
+
+  if (typeof desired.segmentKeepSeconds !== "undefined") {
+    out.SegmentKeepSeconds = desired.segmentKeepSeconds;
+  }
 
   if (typeof desired.enableHardwareEncoding !== "undefined") {
     out.EnableHardwareEncoding = desired.enableHardwareEncoding;
@@ -36,6 +99,14 @@ export function mapEncodingOptionsConfigToSchema(
       desired.enableDecodingColorDepth12HevcRext;
   }
 
+  if (typeof desired.enableEnhancedNvdecDecoder !== "undefined") {
+    out.EnableEnhancedNvdecDecoder = desired.enableEnhancedNvdecDecoder;
+  }
+
+  if (typeof desired.preferSystemNativeHwDecoder !== "undefined") {
+    out.PreferSystemNativeHwDecoder = desired.preferSystemNativeHwDecoder;
+  }
+
   if (typeof desired.vaapiDevice !== "undefined") {
     out.VaapiDevice = desired.vaapiDevice;
   }
@@ -50,6 +121,30 @@ export function mapEncodingOptionsConfigToSchema(
 
   if (typeof desired.allowAv1Encoding !== "undefined") {
     out.AllowAv1Encoding = desired.allowAv1Encoding;
+  }
+
+  if (typeof desired.enableSubtitleExtraction !== "undefined") {
+    out.EnableSubtitleExtraction = desired.enableSubtitleExtraction;
+  }
+
+  if (typeof desired.h264Crf !== "undefined") {
+    out.H264Crf = desired.h264Crf;
+  }
+
+  if (typeof desired.h265Crf !== "undefined") {
+    out.H265Crf = desired.h265Crf;
+  }
+
+  if (typeof desired.deinterlaceMethod !== "undefined") {
+    out.DeinterlaceMethod = desired.deinterlaceMethod;
+  }
+
+  if (typeof desired.deinterlaceDoubleRate !== "undefined") {
+    out.DeinterlaceDoubleRate = desired.deinterlaceDoubleRate;
+  }
+
+  if (desired.tonemapping !== undefined) {
+    mapTonemapping(desired.tonemapping, out);
   }
 
   return out;

--- a/src/mappers/library.ts
+++ b/src/mappers/library.ts
@@ -1,8 +1,86 @@
-import type { VirtualFolderConfig } from "../types/config/library";
+import type {
+  VirtualFolderConfig,
+  LibraryOptionsConfig,
+  TypeOptionsConfig,
+} from "../types/config/library";
 import type {
   LibraryOptionsSchema,
   VirtualFolderInfoSchema,
+  TypeOptionsSchema,
 } from "../types/schema/library";
+
+function mapTypeOptionsConfigToSchema(
+  typeOpts: TypeOptionsConfig[],
+): TypeOptionsSchema[] {
+  return typeOpts.map(
+    (opt: TypeOptionsConfig): TypeOptionsSchema => ({
+      Type: opt.type,
+      ...(opt.metadataFetchers !== undefined && {
+        MetadataFetchers: opt.metadataFetchers,
+      }),
+      ...(opt.metadataFetcherOrder !== undefined && {
+        MetadataFetcherOrder: opt.metadataFetcherOrder,
+      }),
+      ...(opt.imageFetchers !== undefined && {
+        ImageFetchers: opt.imageFetchers,
+      }),
+      ...(opt.imageFetcherOrder !== undefined && {
+        ImageFetcherOrder: opt.imageFetcherOrder,
+      }),
+    }),
+  );
+}
+
+export function mapLibraryOptionsConfigToSchema(
+  opts: LibraryOptionsConfig,
+): LibraryOptionsSchema {
+  const out: LibraryOptionsSchema = {
+    PathInfos: opts.pathInfos.map((p: { path: string }) => ({
+      Path: p.path,
+    })),
+    SaveLyricsWithMedia: false,
+    SaveTrickplayWithMedia: false,
+    PreferNonstandardArtistsTag: false,
+    UseCustomTagDelimiters: false,
+  };
+
+  if (opts.saveLocalMetadata !== undefined)
+    out.SaveLocalMetadata = opts.saveLocalMetadata;
+  if (opts.enableRealtimeMonitor !== undefined)
+    out.EnableRealtimeMonitor = opts.enableRealtimeMonitor;
+  if (opts.enableAutomaticSeriesGrouping !== undefined)
+    out.EnableAutomaticSeriesGrouping = opts.enableAutomaticSeriesGrouping;
+  if (opts.enableEmbeddedTitles !== undefined)
+    out.EnableEmbeddedTitles = opts.enableEmbeddedTitles;
+  if (opts.enableEmbeddedExtrasTitles !== undefined)
+    out.EnableEmbeddedExtrasTitles = opts.enableEmbeddedExtrasTitles;
+  if (opts.enableEmbeddedEpisodeInfos !== undefined)
+    out.EnableEmbeddedEpisodeInfos = opts.enableEmbeddedEpisodeInfos;
+  if (opts.preferredMetadataLanguage !== undefined)
+    out.PreferredMetadataLanguage = opts.preferredMetadataLanguage;
+  if (opts.metadataCountryCode !== undefined)
+    out.MetadataCountryCode = opts.metadataCountryCode;
+  if (opts.enableTrickplayImageExtraction !== undefined)
+    out.EnableTrickplayImageExtraction = opts.enableTrickplayImageExtraction;
+  if (opts.enableChapterImageExtraction !== undefined)
+    out.EnableChapterImageExtraction = opts.enableChapterImageExtraction;
+  if (opts.subtitleDownloadLanguages !== undefined)
+    out.SubtitleDownloadLanguages = opts.subtitleDownloadLanguages;
+  if (opts.skipSubtitlesIfEmbeddedSubtitlesPresent !== undefined)
+    out.SkipSubtitlesIfEmbeddedSubtitlesPresent =
+      opts.skipSubtitlesIfEmbeddedSubtitlesPresent;
+  if (opts.skipSubtitlesIfAudioTrackMatches !== undefined)
+    out.SkipSubtitlesIfAudioTrackMatches =
+      opts.skipSubtitlesIfAudioTrackMatches;
+  if (opts.metadataSavers !== undefined)
+    out.MetadataSavers = opts.metadataSavers;
+  if (opts.enableCrossLibrarySeriesMerging !== undefined)
+    out.AutomaticallyAddToCollection = opts.enableCrossLibrarySeriesMerging;
+  if (opts.typeOptions !== undefined)
+    out.TypeOptions = mapTypeOptionsConfigToSchema(opts.typeOptions);
+
+  return out;
+}
 
 export function mapVirtualFolderConfigToSchema(
   config: VirtualFolderConfig,
@@ -10,13 +88,7 @@ export function mapVirtualFolderConfigToSchema(
   return {
     Name: config.name,
     CollectionType: config.collectionType,
-    LibraryOptions: {
-      PathInfos: config.libraryOptions.pathInfos.map(
-        (pathInfo: { path: string }) => ({
-          Path: pathInfo.path,
-        }),
-      ),
-    } as LibraryOptionsSchema,
+    LibraryOptions: mapLibraryOptionsConfigToSchema(config.libraryOptions),
   };
 }
 

--- a/src/mappers/networking.ts
+++ b/src/mappers/networking.ts
@@ -1,0 +1,58 @@
+import type { NetworkingConfig } from "../types/config/networking";
+import type { NetworkConfigurationSchema } from "../types/schema/networking";
+import type { ServerConfigurationSchema } from "../types/schema/system";
+
+export function mapNetworkingConfigToSchema(
+  desired: NetworkingConfig,
+): Partial<NetworkConfigurationSchema> {
+  const out: Partial<NetworkConfigurationSchema> = {};
+
+  if (desired.baseUrl !== undefined) out.BaseUrl = desired.baseUrl;
+  if (desired.enableHttps !== undefined) out.EnableHttps = desired.enableHttps;
+  if (desired.requireHttps !== undefined)
+    out.RequireHttps = desired.requireHttps;
+  if (desired.internalHttpPort !== undefined)
+    out.InternalHttpPort = desired.internalHttpPort;
+  if (desired.internalHttpsPort !== undefined)
+    out.InternalHttpsPort = desired.internalHttpsPort;
+  if (desired.publicHttpPort !== undefined)
+    out.PublicHttpPort = desired.publicHttpPort;
+  if (desired.publicHttpsPort !== undefined)
+    out.PublicHttpsPort = desired.publicHttpsPort;
+  if (desired.enableRemoteAccess !== undefined)
+    out.EnableRemoteAccess = desired.enableRemoteAccess;
+  if (desired.enableIPv4 !== undefined) out.EnableIPv4 = desired.enableIPv4;
+  if (desired.enableIPv6 !== undefined) out.EnableIPv6 = desired.enableIPv6;
+  if (desired.enableUPnP !== undefined) out.EnableUPnP = desired.enableUPnP;
+  if (desired.knownProxies !== undefined)
+    out.KnownProxies = desired.knownProxies;
+  if (desired.localNetworkSubnets !== undefined)
+    out.LocalNetworkSubnets = desired.localNetworkSubnets;
+  if (desired.localNetworkAddresses !== undefined)
+    out.LocalNetworkAddresses = desired.localNetworkAddresses;
+  if (desired.remoteIpFilter !== undefined)
+    out.RemoteIPFilter = desired.remoteIpFilter;
+  if (desired.isRemoteIpFilterBlacklist !== undefined)
+    out.IsRemoteIPFilterBlacklist = desired.isRemoteIpFilterBlacklist;
+  if (desired.ignoreVirtualInterfaces !== undefined)
+    out.IgnoreVirtualInterfaces = desired.ignoreVirtualInterfaces;
+  if (desired.virtualInterfaceNames !== undefined)
+    out.VirtualInterfaceNames = desired.virtualInterfaceNames;
+  if (desired.enablePublishedServerUriByRequest !== undefined)
+    out.EnablePublishedServerUriByRequest =
+      desired.enablePublishedServerUriByRequest;
+  if (desired.publishedServerUriBySubnet !== undefined)
+    out.PublishedServerUriBySubnet = desired.publishedServerUriBySubnet;
+  if (desired.autoDiscovery !== undefined)
+    out.AutoDiscovery = desired.autoDiscovery;
+
+  return out;
+}
+
+export function mapNetworkingCorsHostsToSystemSchema(
+  desired: NetworkingConfig,
+): Partial<ServerConfigurationSchema> {
+  const out: Partial<ServerConfigurationSchema> = {};
+  if (desired.corsHosts !== undefined) out.CorsHosts = desired.corsHosts;
+  return out;
+}

--- a/src/mappers/system.ts
+++ b/src/mappers/system.ts
@@ -25,8 +25,24 @@ export function toTrickplayOptionsSchema(
   cfg: TrickplayOptionsConfig,
 ): TrickplayOptionsSchema {
   const out: TrickplayOptionsSchema = {};
-  out.EnableHwAcceleration = cfg.enableHwAcceleration;
-  out.EnableHwEncoding = cfg.enableHwEncoding;
+  if (cfg.enableHwAcceleration !== undefined)
+    out.EnableHwAcceleration = cfg.enableHwAcceleration;
+  if (cfg.enableHwEncoding !== undefined)
+    out.EnableHwEncoding = cfg.enableHwEncoding;
+  if (cfg.enableKeyFrameOnlyExtraction !== undefined)
+    out.EnableKeyFrameOnlyExtraction = cfg.enableKeyFrameOnlyExtraction;
+  if (cfg.scanBehavior !== undefined) out.ScanBehavior = cfg.scanBehavior;
+  if (cfg.processPriority !== undefined)
+    out.ProcessPriority = cfg.processPriority;
+  if (cfg.interval !== undefined) out.Interval = cfg.interval;
+  if (cfg.widthResolutions !== undefined)
+    out.WidthResolutions = cfg.widthResolutions;
+  if (cfg.tileWidth !== undefined) out.TileWidth = cfg.tileWidth;
+  if (cfg.tileHeight !== undefined) out.TileHeight = cfg.tileHeight;
+  if (cfg.qscale !== undefined) out.Qscale = cfg.qscale;
+  if (cfg.jpegQuality !== undefined) out.JpegQuality = cfg.jpegQuality;
+  if (cfg.processThreads !== undefined)
+    out.ProcessThreads = cfg.processThreads;
   return out;
 }
 
@@ -35,9 +51,56 @@ export function mapSystemConfigurationConfigToSchema(
 ): Partial<ServerConfigurationSchema> {
   const out: Partial<ServerConfigurationSchema> = {};
 
-  if (desired.enableMetrics !== undefined) {
+  if (desired.serverName !== undefined) out.ServerName = desired.serverName;
+  if (desired.preferredMetadataLanguage !== undefined)
+    out.PreferredMetadataLanguage = desired.preferredMetadataLanguage;
+  if (desired.metadataCountryCode !== undefined)
+    out.MetadataCountryCode = desired.metadataCountryCode;
+  if (desired.uiCulture !== undefined) out.UICulture = desired.uiCulture;
+  if (desired.quickConnectAvailable !== undefined)
+    out.QuickConnectAvailable = desired.quickConnectAvailable;
+  if (desired.enableMetrics !== undefined)
     out.EnableMetrics = desired.enableMetrics;
-  }
+  if (desired.enableFolderView !== undefined)
+    out.EnableFolderView = desired.enableFolderView;
+  if (desired.enableGroupingMoviesIntoCollections !== undefined)
+    out.EnableGroupingMoviesIntoCollections =
+      desired.enableGroupingMoviesIntoCollections;
+  if (desired.enableGroupingShowsIntoCollections !== undefined)
+    out.EnableGroupingShowsIntoCollections =
+      desired.enableGroupingShowsIntoCollections;
+  if (desired.displaySpecialsWithinSeasons !== undefined)
+    out.DisplaySpecialsWithinSeasons = desired.displaySpecialsWithinSeasons;
+  if (desired.enableExternalContentInSuggestions !== undefined)
+    out.EnableExternalContentInSuggestions =
+      desired.enableExternalContentInSuggestions;
+  if (desired.activityLogRetentionDays !== undefined)
+    out.ActivityLogRetentionDays = desired.activityLogRetentionDays;
+  if (desired.logFileRetentionDays !== undefined)
+    out.LogFileRetentionDays = desired.logFileRetentionDays;
+  if (desired.libraryMonitorDelay !== undefined)
+    out.LibraryMonitorDelay = desired.libraryMonitorDelay;
+  if (desired.libraryUpdateDuration !== undefined)
+    out.LibraryUpdateDuration = desired.libraryUpdateDuration;
+  if (desired.libraryScanFanoutConcurrency !== undefined)
+    out.LibraryScanFanoutConcurrency = desired.libraryScanFanoutConcurrency;
+  if (desired.libraryMetadataRefreshConcurrency !== undefined)
+    out.LibraryMetadataRefreshConcurrency =
+      desired.libraryMetadataRefreshConcurrency;
+  if (desired.remoteClientBitrateLimit !== undefined)
+    out.RemoteClientBitrateLimit = desired.remoteClientBitrateLimit;
+  if (desired.minResumePct !== undefined)
+    out.MinResumePct = desired.minResumePct;
+  if (desired.maxResumePct !== undefined)
+    out.MaxResumePct = desired.maxResumePct;
+  if (desired.minResumeDurationSeconds !== undefined)
+    out.MinResumeDurationSeconds = desired.minResumeDurationSeconds;
+  if (desired.sortReplaceCharacters !== undefined)
+    out.SortReplaceCharacters = desired.sortReplaceCharacters;
+  if (desired.sortRemoveCharacters !== undefined)
+    out.SortRemoveCharacters = desired.sortRemoveCharacters;
+  if (desired.sortRemoveWords !== undefined)
+    out.SortRemoveWords = desired.sortRemoveWords;
 
   if (desired.pluginRepositories !== undefined) {
     out.PluginRepositories = toPluginRepositorySchemas(

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -5,7 +5,14 @@ import {
   calculateEncodingDiff,
   applyEncoding,
 } from "../apply/encoding-options";
-import { calculateLibraryDiff, applyLibrary } from "../apply/library";
+import {
+  calculateLibraryDiff,
+  calculateLibraryOptionsDiff,
+  applyLibrary,
+  applyLibraryOptions,
+  purgeLibraries,
+} from "../apply/library";
+import type { LibraryOptionsUpdate } from "../apply/library";
 import {
   calculateBrandingOptionsDiff,
   applyBrandingOptions,
@@ -16,12 +23,23 @@ import {
   applyUserPolicies,
   createNewUsers,
 } from "../apply/users";
+import {
+  calculateNetworkingDiff,
+  applyNetworking,
+} from "../apply/networking";
+import {
+  calculateApiKeysToCreate,
+  createApiKeys,
+} from "../apply/api-keys";
 import type { VirtualFolderInfoSchema } from "../types/schema/library";
 import { type ServerConfigurationSchema } from "../types/schema/system";
 import { type EncodingOptionsSchema } from "../types/schema/encoding-options";
 import { type BrandingOptionsDtoSchema } from "../types/schema/branding-options";
 import type { UserDtoSchema, UserPolicySchema } from "../types/schema/users";
+import type { NetworkConfigurationSchema } from "../types/schema/networking";
+import type { AuthenticationInfoSchema } from "../types/schema/api-keys";
 import type { UserConfig } from "../types/config/users";
+import type { ApiKeyConfig } from "../types/config/api-keys";
 import { createJellyfinClient } from "../api/jellyfin_client";
 import { type JellyfinClient } from "../api/jellyfin.types";
 import { RootConfigType, type RootConfig } from "../types/config/root";
@@ -96,17 +114,41 @@ export async function runPipeline(path: string): Promise<void> {
   }
 
   if (cfg.library?.virtualFolders) {
-    const currentVirtualFolders: VirtualFolderInfoSchema[] =
+    let currentVirtualFolders: VirtualFolderInfoSchema[] =
       await jellyfinClient.getVirtualFolders();
+
+    if (cfg.library.purgeExistingLibraries && currentVirtualFolders.length > 0) {
+      console.log("→ purging existing libraries");
+      await purgeLibraries(jellyfinClient, currentVirtualFolders);
+      console.log("✓ purged existing libraries");
+      currentVirtualFolders = [];
+    }
+
     const foldersToCreate: VirtualFolderInfoSchema[] | undefined =
       calculateLibraryDiff(currentVirtualFolders, cfg.library.virtualFolders);
 
     if (foldersToCreate) {
-      console.log("→ updating library config");
+      console.log("→ creating new libraries");
       await applyLibrary(jellyfinClient, foldersToCreate);
-      console.log("✓ updated library config");
+      console.log("✓ created new libraries");
     } else {
-      console.log("✓ library config already up to date");
+      console.log("✓ libraries already exist");
+    }
+
+    const updatedFolders: VirtualFolderInfoSchema[] =
+      foldersToCreate
+        ? await jellyfinClient.getVirtualFolders()
+        : currentVirtualFolders;
+
+    const libraryOptionsUpdates: LibraryOptionsUpdate[] | undefined =
+      calculateLibraryOptionsDiff(updatedFolders, cfg.library.virtualFolders);
+
+    if (libraryOptionsUpdates) {
+      console.log("→ updating library options");
+      await applyLibraryOptions(jellyfinClient, libraryOptionsUpdates);
+      console.log("✓ updated library options");
+    } else {
+      console.log("✓ library options already up to date");
     }
   }
 
@@ -123,6 +165,38 @@ export async function runPipeline(path: string): Promise<void> {
       console.log("✓ updated branding config");
     } else {
       console.log("✓ branding config already up to date");
+    }
+  }
+
+  if (cfg.networking) {
+    const currentNetworkingSchema: NetworkConfigurationSchema =
+      await jellyfinClient.getNetworkingConfiguration();
+
+    const updatedNetworkingSchema: NetworkConfigurationSchema | undefined =
+      calculateNetworkingDiff(currentNetworkingSchema, cfg.networking);
+
+    if (updatedNetworkingSchema) {
+      console.log("→ updating networking config");
+      await applyNetworking(jellyfinClient, updatedNetworkingSchema);
+      console.log("✓ updated networking config");
+    } else {
+      console.log("✓ networking config already up to date");
+    }
+
+    if (cfg.networking.corsHosts !== undefined) {
+      const currentSystemConfig: ServerConfigurationSchema =
+        await jellyfinClient.getSystemConfiguration();
+      const currentCorsHosts = currentSystemConfig.CorsHosts ?? [];
+      const desiredCorsHosts = cfg.networking.corsHosts;
+
+      if (JSON.stringify(currentCorsHosts) !== JSON.stringify(desiredCorsHosts)) {
+        console.log("→ updating CORS hosts");
+        await jellyfinClient.updateSystemConfiguration({
+          ...currentSystemConfig,
+          CorsHosts: desiredCorsHosts,
+        });
+        console.log("✓ updated CORS hosts");
+      }
     }
   }
 
@@ -188,6 +262,22 @@ export async function runPipeline(path: string): Promise<void> {
       console.log("✓ updated plugin configurations");
     } else {
       console.log("✓ plugin configurations already up to date");
+    }
+  }
+
+  if (cfg.api_keys) {
+    const currentApiKeys: AuthenticationInfoSchema[] =
+      await jellyfinClient.getApiKeys();
+
+    const keysToCreate: ApiKeyConfig[] | undefined =
+      calculateApiKeysToCreate(currentApiKeys, cfg.api_keys);
+
+    if (keysToCreate) {
+      console.log("→ creating API keys");
+      await createApiKeys(jellyfinClient, keysToCreate);
+      console.log("✓ created API keys");
+    } else {
+      console.log("✓ API keys already up to date");
     }
   }
 

--- a/src/types/config/api-keys.ts
+++ b/src/types/config/api-keys.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const ApiKeyConfigType = z
+  .object({
+    name: z.string().min(1, "API key name cannot be empty"),
+  })
+  .strict();
+
+export type ApiKeyConfig = z.infer<typeof ApiKeyConfigType>;
+
+export const ApiKeyConfigListType = z.array(ApiKeyConfigType);
+
+export type ApiKeyConfigList = z.infer<typeof ApiKeyConfigListType>;

--- a/src/types/config/encoding-options.ts
+++ b/src/types/config/encoding-options.ts
@@ -1,42 +1,63 @@
 import { z } from "zod";
 
-export const EncodingOptionsConfigType: z.ZodObject<{
-  enableHardwareEncoding: z.ZodOptional<z.ZodBoolean>;
-  hardwareAccelerationType: z.ZodOptional<
-    z.ZodEnum<{
-      none: "none";
-      amf: "amf";
-      qsv: "qsv";
-      nvenc: "nvenc";
-      v4l2m2m: "v4l2m2m";
-      vaapi: "vaapi";
-      videotoolbox: "videotoolbox";
-      rkmpp: "rkmpp";
-    }>
-  >;
-  vaapiDevice: z.ZodOptional<z.ZodString>;
-  qsvDevice: z.ZodOptional<z.ZodString>;
-  hardwareDecodingCodecs: z.ZodOptional<
-    z.ZodArray<
-      z.ZodEnum<{
-        h264: "h264";
-        hevc: "hevc";
-        mpeg2video: "mpeg2video";
-        vc1: "vc1";
-        vp8: "vp8";
-        vp9: "vp9";
-        av1: "av1";
-      }>
-    >
-  >;
-  enableDecodingColorDepth10Hevc: z.ZodOptional<z.ZodBoolean>;
-  enableDecodingColorDepth10Vp9: z.ZodOptional<z.ZodBoolean>;
-  enableDecodingColorDepth10HevcRext: z.ZodOptional<z.ZodBoolean>;
-  enableDecodingColorDepth12HevcRext: z.ZodOptional<z.ZodBoolean>;
-  allowHevcEncoding: z.ZodOptional<z.ZodBoolean>;
-  allowAv1Encoding: z.ZodOptional<z.ZodBoolean>;
-}> = z
+export const TonemappingConfigType = z.object({
+  enabled: z.boolean().optional(),
+  algorithm: z
+    .enum([
+      "none",
+      "clip",
+      "linear",
+      "gamma",
+      "reinhard",
+      "hable",
+      "mobius",
+      "bt2390",
+    ])
+    .optional(),
+  mode: z
+    .enum([
+      "auto",
+      "max",
+      "rgb",
+      "lum",
+      "itp",
+    ])
+    .optional(),
+  range: z
+    .enum([
+      "auto",
+      "tv",
+      "pc",
+    ])
+    .optional(),
+  desat: z.number().optional(),
+  peak: z.number().optional(),
+});
+
+export type TonemappingConfig = z.infer<typeof TonemappingConfigType>;
+
+export const EncodingOptionsConfigType = z
   .object({
+    encodingThreadCount: z.number().int().optional(),
+    transcodingTempPath: z.string().optional(),
+    enableFallbackFont: z.boolean().optional(),
+    fallbackFontPath: z.string().optional(),
+    enableAudioVbr: z.boolean().optional(),
+    downMixAudioBoost: z.number().optional(),
+    downMixStereoAlgorithm: z
+      .enum([
+        "None",
+        "Dave750",
+        "NightmodeDialogue",
+        "Rfc7845",
+        "Ac4",
+      ])
+      .optional(),
+    maxMuxingQueueSize: z.number().int().optional(),
+    enableThrottling: z.boolean().optional(),
+    throttleDelaySeconds: z.number().int().optional(),
+    enableSegmentDeletion: z.boolean().optional(),
+    segmentKeepSeconds: z.number().int().optional(),
     enableHardwareEncoding: z.boolean().optional(),
     hardwareAccelerationType: z
       .enum([
@@ -53,14 +74,38 @@ export const EncodingOptionsConfigType: z.ZodObject<{
     vaapiDevice: z.string().optional(),
     qsvDevice: z.string().optional(),
     hardwareDecodingCodecs: z
-      .array(z.enum(["h264", "hevc", "mpeg2video", "vc1", "vp8", "vp9", "av1"]))
+      .array(
+        z.enum([
+          "h264",
+          "hevc",
+          "mpeg2video",
+          "vc1",
+          "vp8",
+          "vp9",
+          "av1",
+        ]),
+      )
       .optional(),
     enableDecodingColorDepth10Hevc: z.boolean().optional(),
     enableDecodingColorDepth10Vp9: z.boolean().optional(),
     enableDecodingColorDepth10HevcRext: z.boolean().optional(),
     enableDecodingColorDepth12HevcRext: z.boolean().optional(),
+    enableEnhancedNvdecDecoder: z.boolean().optional(),
+    preferSystemNativeHwDecoder: z.boolean().optional(),
     allowHevcEncoding: z.boolean().optional(),
     allowAv1Encoding: z.boolean().optional(),
+    enableSubtitleExtraction: z.boolean().optional(),
+    subtitleExtractionTimeoutMinutes: z.number().int().optional(),
+    h264Crf: z.number().int().optional(),
+    h265Crf: z.number().int().optional(),
+    deinterlaceMethod: z
+      .enum([
+        "yadif",
+        "bwdif",
+      ])
+      .optional(),
+    deinterlaceDoubleRate: z.boolean().optional(),
+    tonemapping: TonemappingConfigType.optional(),
   })
   .strict();
 

--- a/src/types/config/library.ts
+++ b/src/types/config/library.ts
@@ -1,25 +1,44 @@
 import { z } from "zod";
 
-export const VirtualFolderConfigType: z.ZodObject<{
-  name: z.ZodString;
-  collectionType: z.ZodEnum<{
-    movies: "movies";
-    tvshows: "tvshows";
-    music: "music";
-    musicvideos: "musicvideos";
-    homevideos: "homevideos";
-    boxsets: "boxsets";
-    books: "books";
-    mixed: "mixed";
-  }>;
-  libraryOptions: z.ZodObject<{
-    pathInfos: z.ZodArray<
-      z.ZodObject<{
-        path: z.ZodString;
-      }>
-    >;
-  }>;
-}> = z
+export const TypeOptionsConfigType = z
+  .object({
+    type: z.string().min(1),
+    metadataFetchers: z.array(z.string()).optional(),
+    metadataFetcherOrder: z.array(z.string()).optional(),
+    imageFetchers: z.array(z.string()).optional(),
+    imageFetcherOrder: z.array(z.string()).optional(),
+  })
+  .strict();
+
+export type TypeOptionsConfig = z.infer<typeof TypeOptionsConfigType>;
+
+export const LibraryOptionsConfigType = z
+  .object({
+    pathInfos: z
+      .array(z.object({ path: z.string().min(1) }).strict())
+      .min(1),
+    saveLocalMetadata: z.boolean().optional(),
+    enableRealtimeMonitor: z.boolean().optional(),
+    enableAutomaticSeriesGrouping: z.boolean().optional(),
+    enableEmbeddedTitles: z.boolean().optional(),
+    enableEmbeddedExtrasTitles: z.boolean().optional(),
+    enableEmbeddedEpisodeInfos: z.boolean().optional(),
+    preferredMetadataLanguage: z.string().optional(),
+    metadataCountryCode: z.string().optional(),
+    enableTrickplayImageExtraction: z.boolean().optional(),
+    enableChapterImageExtraction: z.boolean().optional(),
+    subtitleDownloadLanguages: z.array(z.string()).optional(),
+    skipSubtitlesIfEmbeddedSubtitlesPresent: z.boolean().optional(),
+    skipSubtitlesIfAudioTrackMatches: z.boolean().optional(),
+    metadataSavers: z.array(z.string()).optional(),
+    enableCrossLibrarySeriesMerging: z.boolean().optional(),
+    typeOptions: z.array(TypeOptionsConfigType).optional(),
+  })
+  .strict();
+
+export type LibraryOptionsConfig = z.infer<typeof LibraryOptionsConfigType>;
+
+export const VirtualFolderConfigType = z
   .object({
     name: z.string().min(1),
     collectionType: z.enum([
@@ -32,22 +51,15 @@ export const VirtualFolderConfigType: z.ZodObject<{
       "books",
       "mixed",
     ]),
-    libraryOptions: z
-      .object({
-        pathInfos: z
-          .array(z.object({ path: z.string().min(1) }).strict())
-          .min(1),
-      })
-      .strict(),
+    libraryOptions: LibraryOptionsConfigType,
   })
   .strict();
 
 export type VirtualFolderConfig = z.infer<typeof VirtualFolderConfigType>;
 
-export const LibraryConfigType: z.ZodObject<{
-  virtualFolders: z.ZodOptional<z.ZodArray<typeof VirtualFolderConfigType>>;
-}> = z
+export const LibraryConfigType = z
   .object({
+    purgeExistingLibraries: z.boolean().optional(),
     virtualFolders: z.array(VirtualFolderConfigType).optional(),
   })
   .strict();

--- a/src/types/config/networking.ts
+++ b/src/types/config/networking.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+export const NetworkingConfigType = z
+  .object({
+    baseUrl: z.string().optional(),
+    enableHttps: z.boolean().optional(),
+    requireHttps: z.boolean().optional(),
+    internalHttpPort: z.number().int().optional(),
+    internalHttpsPort: z.number().int().optional(),
+    publicHttpPort: z.number().int().optional(),
+    publicHttpsPort: z.number().int().optional(),
+    enableRemoteAccess: z.boolean().optional(),
+    enableIPv4: z.boolean().optional(),
+    enableIPv6: z.boolean().optional(),
+    autoDiscovery: z.boolean().optional(),
+    enableUPnP: z.boolean().optional(),
+    knownProxies: z.array(z.string()).optional(),
+    localNetworkSubnets: z.array(z.string()).optional(),
+    localNetworkAddresses: z.array(z.string()).optional(),
+    remoteIpFilter: z.array(z.string()).optional(),
+    isRemoteIpFilterBlacklist: z.boolean().optional(),
+    ignoreVirtualInterfaces: z.boolean().optional(),
+    virtualInterfaceNames: z.array(z.string()).optional(),
+    enablePublishedServerUriByRequest: z.boolean().optional(),
+    publishedServerUriBySubnet: z.array(z.string()).optional(),
+    corsHosts: z.array(z.string()).optional(),
+  })
+  .strict();
+
+export type NetworkingConfig = z.infer<typeof NetworkingConfigType>;

--- a/src/types/config/root.ts
+++ b/src/types/config/root.ts
@@ -6,18 +6,10 @@ import { BrandingOptionsConfigType } from "./branding-options";
 import { UserConfigListType } from "./users";
 import { StartupConfigType } from "./startup";
 import { PluginConfigListType } from "./plugins";
+import { NetworkingConfigType } from "./networking";
+import { ApiKeyConfigListType } from "./api-keys";
 
-export const RootConfigType: z.ZodObject<{
-  version: z.ZodNumber;
-  base_url: z.ZodURL;
-  system: typeof SystemConfigType;
-  encoding: z.ZodOptional<typeof EncodingOptionsConfigType>;
-  library: z.ZodOptional<typeof LibraryConfigType>;
-  branding: z.ZodOptional<typeof BrandingOptionsConfigType>;
-  users: z.ZodOptional<typeof UserConfigListType>;
-  plugins: z.ZodOptional<typeof PluginConfigListType>;
-  startup: z.ZodOptional<typeof StartupConfigType>;
-}> = z
+export const RootConfigType = z
   .object({
     version: z.number().int().positive("Version must be a positive integer"),
     base_url: z.url({ message: "Base URL must be a valid URL" }),
@@ -28,6 +20,8 @@ export const RootConfigType: z.ZodObject<{
     users: UserConfigListType.optional(),
     plugins: PluginConfigListType.optional(),
     startup: StartupConfigType.optional(),
+    networking: NetworkingConfigType.optional(),
+    api_keys: ApiKeyConfigListType.optional(),
   })
   .strict();
 

--- a/src/types/config/system.ts
+++ b/src/types/config/system.ts
@@ -1,10 +1,6 @@
 import { z } from "zod";
 
-export const PluginRepositoryConfigType: z.ZodObject<{
-  name: z.ZodString;
-  url: z.ZodURL;
-  enabled: z.ZodBoolean;
-}> = z.object({
+export const PluginRepositoryConfigType = z.object({
   name: z.string().min(1, "Plugin repository name cannot be empty"),
   url: z.url({ message: "Plugin repository URL must be a valid URL" }),
   enabled: z.boolean(),
@@ -12,25 +8,63 @@ export const PluginRepositoryConfigType: z.ZodObject<{
 
 export type PluginRepositoryConfig = z.infer<typeof PluginRepositoryConfigType>;
 
-export const TrickplayOptionsConfigType: z.ZodObject<{
-  enableHwAcceleration: z.ZodOptional<z.ZodBoolean>;
-  enableHwEncoding: z.ZodOptional<z.ZodBoolean>;
-}> = z.object({
+export const TrickplayOptionsConfigType = z.object({
   enableHwAcceleration: z.boolean().optional(),
   enableHwEncoding: z.boolean().optional(),
+  enableKeyFrameOnlyExtraction: z.boolean().optional(),
+  scanBehavior: z
+    .enum([
+      "Blocking",
+      "NonBlocking",
+    ])
+    .optional(),
+  processPriority: z
+    .enum([
+      "Normal",
+      "Idle",
+      "High",
+      "RealTime",
+      "BelowNormal",
+      "AboveNormal",
+    ])
+    .optional(),
+  interval: z.number().int().optional(),
+  widthResolutions: z.array(z.number().int()).optional(),
+  tileWidth: z.number().int().optional(),
+  tileHeight: z.number().int().optional(),
+  qscale: z.number().int().optional(),
+  jpegQuality: z.number().int().optional(),
+  processThreads: z.number().int().optional(),
 });
 
 export type TrickplayOptionsConfig = z.infer<typeof TrickplayOptionsConfigType>;
 
-export const SystemConfigType: z.ZodObject<{
-  enableMetrics: z.ZodOptional<z.ZodBoolean>;
-  pluginRepositories: z.ZodOptional<
-    z.ZodArray<typeof PluginRepositoryConfigType>
-  >;
-  trickplayOptions: z.ZodOptional<typeof TrickplayOptionsConfigType>;
-}> = z
+export const SystemConfigType = z
   .object({
+    serverName: z.string().optional(),
+    preferredMetadataLanguage: z.string().optional(),
+    metadataCountryCode: z.string().optional(),
+    uiCulture: z.string().optional(),
+    quickConnectAvailable: z.boolean().optional(),
     enableMetrics: z.boolean().optional(),
+    enableFolderView: z.boolean().optional(),
+    enableGroupingMoviesIntoCollections: z.boolean().optional(),
+    enableGroupingShowsIntoCollections: z.boolean().optional(),
+    displaySpecialsWithinSeasons: z.boolean().optional(),
+    enableExternalContentInSuggestions: z.boolean().optional(),
+    activityLogRetentionDays: z.number().int().optional(),
+    logFileRetentionDays: z.number().int().optional(),
+    libraryMonitorDelay: z.number().int().optional(),
+    libraryUpdateDuration: z.number().int().optional(),
+    libraryScanFanoutConcurrency: z.number().int().optional(),
+    libraryMetadataRefreshConcurrency: z.number().int().optional(),
+    remoteClientBitrateLimit: z.number().int().optional(),
+    minResumePct: z.number().int().optional(),
+    maxResumePct: z.number().int().optional(),
+    minResumeDurationSeconds: z.number().int().optional(),
+    sortReplaceCharacters: z.array(z.string()).optional(),
+    sortRemoveCharacters: z.array(z.string()).optional(),
+    sortRemoveWords: z.array(z.string()).optional(),
     pluginRepositories: z.array(PluginRepositoryConfigType).optional(),
     trickplayOptions: TrickplayOptionsConfigType.optional(),
   })

--- a/src/types/schema/api-keys.ts
+++ b/src/types/schema/api-keys.ts
@@ -1,0 +1,7 @@
+import type { components } from "../../../generated/schema";
+
+export type AuthenticationInfoSchema =
+  components["schemas"]["AuthenticationInfo"];
+
+export type AuthenticationInfoQueryResultSchema =
+  components["schemas"]["AuthenticationInfoQueryResult"];

--- a/src/types/schema/library.ts
+++ b/src/types/schema/library.ts
@@ -10,3 +10,6 @@ export type CollectionTypeSchema = NonNullable<
 >;
 export type LibraryOptionsSchema = components["schemas"]["LibraryOptions"];
 export type MediaPathInfoSchema = components["schemas"]["MediaPathInfo"];
+export type TypeOptionsSchema = components["schemas"]["TypeOptions"];
+export type UpdateLibraryOptionsDtoSchema =
+  components["schemas"]["UpdateLibraryOptionsDto"];

--- a/src/types/schema/networking.ts
+++ b/src/types/schema/networking.ts
@@ -1,0 +1,4 @@
+import type { components } from "../../../generated/schema";
+
+export type NetworkConfigurationSchema =
+  components["schemas"]["NetworkConfiguration"];

--- a/tests/apply/library.spec.ts
+++ b/tests/apply/library.spec.ts
@@ -87,6 +87,10 @@ describe("apply/library", () => {
           CollectionType: "movies",
           LibraryOptions: {
             PathInfos: [{ Path: "/data/movies" }],
+            SaveLyricsWithMedia: false,
+            SaveTrickplayWithMedia: false,
+            PreferNonstandardArtistsTag: false,
+            UseCustomTagDelimiters: false,
           },
         },
       ]);
@@ -100,6 +104,10 @@ describe("apply/library", () => {
           CollectionType: "movies",
           LibraryOptions: {
             PathInfos: [{ Path: "/data/movies" }],
+            SaveLyricsWithMedia: false,
+            SaveTrickplayWithMedia: false,
+            PreferNonstandardArtistsTag: false,
+            UseCustomTagDelimiters: false,
           } as LibraryOptionsSchema,
         },
       ];
@@ -138,6 +146,10 @@ describe("apply/library", () => {
               { Path: "/data/path1" },
               { Path: "/data/path3" },
             ],
+            SaveLyricsWithMedia: false,
+            SaveTrickplayWithMedia: false,
+            PreferNonstandardArtistsTag: false,
+            UseCustomTagDelimiters: false,
           } as LibraryOptionsSchema,
         },
       ];
@@ -176,6 +188,10 @@ describe("apply/library", () => {
           CollectionType: "movies",
           LibraryOptions: {
             PathInfos: [{ Path: "/path/old" }],
+            SaveLyricsWithMedia: false,
+            SaveTrickplayWithMedia: false,
+            PreferNonstandardArtistsTag: false,
+            UseCustomTagDelimiters: false,
           } as LibraryOptionsSchema,
         },
       ];
@@ -210,6 +226,10 @@ describe("apply/library", () => {
           CollectionType: "movies",
           LibraryOptions: {
             PathInfos: [{ Path: "/data/movies" }],
+            SaveLyricsWithMedia: false,
+            SaveTrickplayWithMedia: false,
+            PreferNonstandardArtistsTag: false,
+            UseCustomTagDelimiters: false,
           } as LibraryOptionsSchema,
         },
       ];
@@ -244,6 +264,10 @@ describe("apply/library", () => {
           CollectionType: "movies",
           LibraryOptions: {
             PathInfos: [{ Path: "/data/existing" }],
+            SaveLyricsWithMedia: false,
+            SaveTrickplayWithMedia: false,
+            PreferNonstandardArtistsTag: false,
+            UseCustomTagDelimiters: false,
           } as LibraryOptionsSchema,
         },
       ];
@@ -280,6 +304,10 @@ describe("apply/library", () => {
           CollectionType: "tvshows",
           LibraryOptions: {
             PathInfos: [{ Path: "/data/shows" }],
+            SaveLyricsWithMedia: false,
+            SaveTrickplayWithMedia: false,
+            PreferNonstandardArtistsTag: false,
+            UseCustomTagDelimiters: false,
           },
         },
       ]);
@@ -311,6 +339,10 @@ describe("apply/library", () => {
           CollectionType: "movies",
           LibraryOptions: {
             PathInfos: [{ Path: "/data/movies" }],
+            SaveLyricsWithMedia: false,
+            SaveTrickplayWithMedia: false,
+            PreferNonstandardArtistsTag: false,
+            UseCustomTagDelimiters: false,
           } as LibraryOptionsSchema,
         },
       ];
@@ -323,9 +355,9 @@ describe("apply/library", () => {
       // Assert
       expect(addVirtualFolderSpy).toHaveBeenCalledTimes(1);
       expect(addVirtualFolderSpy).toHaveBeenCalledWith("Movies", "movies", {
-        LibraryOptions: {
+        LibraryOptions: expect.objectContaining({
           PathInfos: [{ Path: "/data/movies" }],
-        },
+        }),
       });
       expect(loggerSpy).toHaveBeenCalledWith("Creating virtual folder: Movies");
       expect(loggerSpy).toHaveBeenCalledWith(
@@ -341,6 +373,10 @@ describe("apply/library", () => {
           CollectionType: "movies",
           LibraryOptions: {
             PathInfos: [{ Path: "/data/movies" }],
+            SaveLyricsWithMedia: false,
+            SaveTrickplayWithMedia: false,
+            PreferNonstandardArtistsTag: false,
+            UseCustomTagDelimiters: false,
           } as LibraryOptionsSchema,
         },
         {
@@ -348,6 +384,10 @@ describe("apply/library", () => {
           CollectionType: "tvshows",
           LibraryOptions: {
             PathInfos: [{ Path: "/data/shows" }],
+            SaveLyricsWithMedia: false,
+            SaveTrickplayWithMedia: false,
+            PreferNonstandardArtistsTag: false,
+            UseCustomTagDelimiters: false,
           } as LibraryOptionsSchema,
         },
       ];

--- a/tests/mappers/library.spec.ts
+++ b/tests/mappers/library.spec.ts
@@ -25,6 +25,10 @@ describe("mappers/library", () => {
         CollectionType: "movies",
         LibraryOptions: {
           PathInfos: [{ Path: "/data/movies" }],
+          SaveLyricsWithMedia: false,
+          SaveTrickplayWithMedia: false,
+          PreferNonstandardArtistsTag: false,
+          UseCustomTagDelimiters: false,
         },
       });
     });


### PR DESCRIPTION
This is vibe coded with Claude Opus but I did actually direct the changes, test the changes, and reviewed the code. It is all also pretty boilerplate.

The motivation for doing this was to get Jellarr to a state where I could use it to fully (within reason) restore my personal Jellyfin config.

Here's the example config I made and tested on my Windows dev machine:
[jellarr_config_example.yml](https://github.com/user-attachments/files/25806909/jellarr_config_example.yml)


Summary (Claude Generated):

**New config sections:**
- Add networking config (`src/types/config/networking.ts`, `src/types/schema/networking.ts`, `src/mappers/networking.ts`, `src/apply/networking.ts`) with 18+ fields including ports, HTTPS, remote access, UPnP, known proxies, local network subnets, remote IP filtering, virtual interfaces, published server URI, and auto discovery. CORS hosts handled separately via system config since Jellyfin stores them on ServerConfiguration.
- Add API keys config (`src/types/config/api-keys.ts`, `src/types/schema/api-keys.ts`, `src/apply/api-keys.ts`) with create-only semantics matching by app name against existing keys.

**Expanded system config (`src/types/config/system.ts`, `src/mappers/system.ts`, `src/apply/system.ts`):**
- Add 31 keys including serverName, preferredMetadataLanguage, metadataCountryCode, uiCulture, quickConnectAvailable, enableFolderView, enableGroupingMoviesIntoCollections, displaySpecialsWithinSeasons, activityLogRetentionDays, logFileRetentionDays, libraryMonitorDelay, libraryUpdateDuration, libraryScanFanoutConcurrency, libraryMetadataRefreshConcurrency, remoteClientBitrateLimit, minResumePct, maxResumePct, minResumeDurationSeconds, sortReplaceCharacters, sortRemoveCharacters, sortRemoveWords.
- Expand trickplayOptions with enableKeyFrameOnlyExtraction, scanBehavior, processPriority, interval, widthResolutions, tileWidth, tileHeight, qscale, jpegQuality, processThreads.

**Expanded encoding config (`src/types/config/encoding-options.ts`, `src/mappers/encoding-options.ts`):**
- Add encodingThreadCount, transcodingTempPath, enableFallbackFont, fallbackFontPath, enableAudioVbr, downMixAudioBoost, downMixStereoAlgorithm, maxMuxingQueueSize, enableThrottling, throttleDelaySeconds, enableSegmentDeletion, segmentKeepSeconds, h264Crf, h265Crf, deinterlaceMethod, deinterlaceDoubleRate, enableEnhancedNvdecDecoder, preferSystemNativeHwDecoder, enableSubtitleExtraction.
- Add tonemapping nested object with enabled, algorithm, mode, range, desat, peak fields mapped via `mapTonemapping` helper.

**Expanded library config (`src/types/config/library.ts`, `src/mappers/library.ts`, `src/apply/library.ts`):**
- Add preferredMetadataLanguage, metadataCountryCode, enableEmbeddedExtrasTitles, enableEmbeddedEpisodeInfos, skipSubtitlesIfAudioTrackMatches, enableCrossLibrarySeriesMerging (mapped to AutomaticallyAddToCollection), metadataSavers to library options.
- Add typeOptions array with type, metadataFetchers, metadataFetcherOrder, imageFetchers, imageFetcherOrder via `mapTypeOptionsConfigToSchema`.
- Remove ChangeSetBuilder/atomize-based library creation diff (`calculateLibraryDiff`). Replace with simple name-based Set comparison against current folder names. The old approach produced phantom ADD entries for nested property changes on existing libraries, creating objects without a Name field.
- Add `purgeExistingLibraries` boolean flag to LibraryConfigType. When true, all existing virtual folders are removed before creating the ones defined in config.
- Add `purgeLibraries` function and `removeVirtualFolder` API client method using `DELETE /Library/VirtualFolders`.

**API client (`src/api/jellyfin_client.ts`, `src/api/jellyfin.types.ts`):**
- Add getNetworkingConfiguration, updateNetworkingConfiguration (using config key "network", not "networking").
- Add getApiKeys, createApiKey using `/Auth/Keys` endpoints.
- Add removeVirtualFolder using `DELETE /Library/VirtualFolders`.

**Pipeline (`src/pipeline/index.ts`):**
- Add networking stage with special CORS hosts handling via system config.
- Add API keys stage (create-only).
- Add library purge step gated on purgeExistingLibraries flag.

**Dump (`src/dump/index.ts`):**
- Export all new config sections: networking, API keys, expanded system fields, expanded encoding fields including tonemapping, full library options with typeOptions.