### PR TITLE
feat: full startup wizard automation with admin user and API key creation

### DIFF
--- a/nix/module/types/startup.nix
+++ b/nix/module/types/startup.nix
@@ -3,8 +3,80 @@
 
   inherit (types) nullOr;
 
+  remoteAccessConfigType = types.submodule {
+    options = {
+      enableRemoteAccess = mkOption {
+        type = types.bool;
+        description = "Enable remote access.";
+      };
+      enableAutomaticPortMapping = mkOption {
+        type = types.bool;
+        description = "Enable automatic port mapping (UPnP). Deprecated in Jellyfin.";
+      };
+    };
+  };
+
+  startupUserConfigType = types.submodule {
+    options = {
+      name = mkOption {
+        type = types.str;
+        description = "The admin user name.";
+      };
+      password = mkOption {
+        type = nullOr types.str;
+        default = null;
+        description = "The admin user password. Mutually exclusive with passwordFile.";
+      };
+      passwordFile = mkOption {
+        type = nullOr types.str;
+        default = null;
+        description = "Path to a file containing the admin user password. Mutually exclusive with password.";
+      };
+    };
+  };
+
   startupConfigType = types.submodule {
     options = {
+      serverName = mkOption {
+        type = nullOr types.str;
+        default = null;
+        description = "The server name to set during startup.";
+      };
+      preferredMetadataLanguage = mkOption {
+        type = nullOr types.str;
+        default = null;
+        description = "Preferred metadata language.";
+      };
+      metadataCountryCode = mkOption {
+        type = nullOr types.str;
+        default = null;
+        description = "Metadata country code.";
+      };
+      uiCulture = mkOption {
+        type = nullOr types.str;
+        default = null;
+        description = "UI language culture.";
+      };
+      remoteAccess = mkOption {
+        type = nullOr remoteAccessConfigType;
+        default = null;
+        description = "Remote access settings.";
+      };
+      user = mkOption {
+        type = nullOr startupUserConfigType;
+        default = null;
+        description = "Initial admin user to create during startup wizard.";
+      };
+      apiKeyApp = mkOption {
+        type = nullOr types.str;
+        default = null;
+        description = "App name for the API key to create.";
+      };
+      apiKeyFile = mkOption {
+        type = nullOr types.str;
+        default = null;
+        description = "File path to write the created API key to.";
+      };
       completeStartupWizard = mkOption {
         type = nullOr types.bool;
         default = null;
@@ -15,7 +87,24 @@
 
   mkStartupConfig = cfg:
     {}
-    // optionalAttrs (cfg.completeStartupWizard != null) {inherit (cfg) completeStartupWizard;};
+    // optionalAttrs ((cfg ? serverName) && cfg.serverName != null) {inherit (cfg) serverName;}
+    // optionalAttrs ((cfg ? preferredMetadataLanguage) && cfg.preferredMetadataLanguage != null) {inherit (cfg) preferredMetadataLanguage;}
+    // optionalAttrs ((cfg ? metadataCountryCode) && cfg.metadataCountryCode != null) {inherit (cfg) metadataCountryCode;}
+    // optionalAttrs ((cfg ? uiCulture) && cfg.uiCulture != null) {inherit (cfg) uiCulture;}
+    // optionalAttrs ((cfg ? remoteAccess) && cfg.remoteAccess != null) {
+      remoteAccess = {
+        inherit (cfg.remoteAccess) enableRemoteAccess enableAutomaticPortMapping;
+      };
+    }
+    // optionalAttrs ((cfg ? user) && cfg.user != null) {
+      user =
+        {inherit (cfg.user) name;}
+        // optionalAttrs (cfg.user.password != null) {inherit (cfg.user) password;}
+        // optionalAttrs (cfg.user.passwordFile != null) {inherit (cfg.user) passwordFile;};
+    }
+    // optionalAttrs ((cfg ? apiKeyApp) && cfg.apiKeyApp != null) {inherit (cfg) apiKeyApp;}
+    // optionalAttrs ((cfg ? apiKeyFile) && cfg.apiKeyFile != null) {inherit (cfg) apiKeyFile;}
+    // optionalAttrs ((cfg ? completeStartupWizard) && cfg.completeStartupWizard != null) {inherit (cfg) completeStartupWizard;};
 in {
   inherit startupConfigType mkStartupConfig;
 }

--- a/nix/tests/module/types/startup.nix
+++ b/nix/tests/module/types/startup.nix
@@ -5,14 +5,127 @@
 }: let
   types = import ../../../module/types {inherit lib;};
   inherit (types.startup) mkStartupConfig;
+
+  defaultCfg = {
+    serverName = null;
+    preferredMetadataLanguage = null;
+    metadataCountryCode = null;
+    uiCulture = null;
+    remoteAccess = null;
+    user = null;
+    apiKeyApp = null;
+    apiKeyFile = null;
+    completeStartupWizard = null;
+  };
 in [
-  (assertEq "completeStartupWizard true" (mkStartupConfig {completeStartupWizard = true;}) {
+  (assertEq "completeStartupWizard true" (mkStartupConfig (defaultCfg // {completeStartupWizard = true;})) {
     completeStartupWizard = true;
   })
 
-  (assertEq "completeStartupWizard false" (mkStartupConfig {completeStartupWizard = false;}) {
+  (assertEq "completeStartupWizard false" (mkStartupConfig (defaultCfg // {completeStartupWizard = false;})) {
     completeStartupWizard = false;
   })
 
-  (assertEq "empty config" (mkStartupConfig {completeStartupWizard = null;}) {})
+  (assertEq "empty config" (mkStartupConfig defaultCfg) {})
+
+  (assertEq "serverName" (mkStartupConfig (defaultCfg // {serverName = "My Jellyfin";})) {
+    serverName = "My Jellyfin";
+  })
+
+  (assertEq "metadata fields" (mkStartupConfig (defaultCfg
+    // {
+      preferredMetadataLanguage = "en";
+      metadataCountryCode = "US";
+      uiCulture = "en-US";
+    })) {
+    preferredMetadataLanguage = "en";
+    metadataCountryCode = "US";
+    uiCulture = "en-US";
+  })
+
+  (assertEq "remoteAccess" (mkStartupConfig (defaultCfg
+    // {
+      remoteAccess = {
+        enableRemoteAccess = true;
+        enableAutomaticPortMapping = false;
+      };
+    })) {
+    remoteAccess = {
+      enableRemoteAccess = true;
+      enableAutomaticPortMapping = false;
+    };
+  })
+
+  (assertEq "user with password" (mkStartupConfig (defaultCfg
+    // {
+      user = {
+        name = "admin";
+        password = "secret";
+        passwordFile = null;
+      };
+    })) {
+    user = {
+      name = "admin";
+      password = "secret";
+    };
+  })
+
+  (assertEq "user with passwordFile" (mkStartupConfig (defaultCfg
+    // {
+      user = {
+        name = "admin";
+        password = null;
+        passwordFile = "/run/secrets/pw";
+      };
+    })) {
+    user = {
+      name = "admin";
+      passwordFile = "/run/secrets/pw";
+    };
+  })
+
+  (assertEq "apiKeyApp and apiKeyFile" (mkStartupConfig (defaultCfg
+    // {
+      apiKeyApp = "jellarr";
+      apiKeyFile = "/run/jellarr/api-key";
+    })) {
+    apiKeyApp = "jellarr";
+    apiKeyFile = "/run/jellarr/api-key";
+  })
+
+  (assertEq "full config" (mkStartupConfig (defaultCfg
+    // {
+      serverName = "My Jellyfin";
+      preferredMetadataLanguage = "en";
+      metadataCountryCode = "US";
+      uiCulture = "en-US";
+      remoteAccess = {
+        enableRemoteAccess = true;
+        enableAutomaticPortMapping = false;
+      };
+      user = {
+        name = "admin";
+        password = "secret";
+        passwordFile = null;
+      };
+      apiKeyApp = "jellarr";
+      apiKeyFile = "/run/jellarr/api-key";
+      completeStartupWizard = true;
+    })) {
+    serverName = "My Jellyfin";
+    preferredMetadataLanguage = "en";
+    metadataCountryCode = "US";
+    uiCulture = "en-US";
+    remoteAccess = {
+      enableRemoteAccess = true;
+      enableAutomaticPortMapping = false;
+    };
+    user = {
+      name = "admin";
+      password = "secret";
+    };
+    apiKeyApp = "jellarr";
+    apiKeyFile = "/run/jellarr/api-key";
+    completeStartupWizard = true;
+  })
 ]

--- a/scripts/test-startup.sh
+++ b/scripts/test-startup.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TMPDIR=$(mktemp -d)
+PORT=$((19000 + RANDOM % 1000))
+BASE_URL="http://localhost:$PORT"
+JF_LOG="$TMPDIR/jf.log"
+
+cleanup() {
+  echo "cleaning up..."
+  kill "$JF_PID" 2>/dev/null || true
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+echo "==> setting up jellyfin config (port $PORT)"
+mkdir -p "$TMPDIR/config"
+cat > "$TMPDIR/config/network.xml" <<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<NetworkConfiguration>
+  <InternalHttpPort>$PORT</InternalHttpPort>
+  <InternalHttpsPort>$((PORT + 1))</InternalHttpsPort>
+  <PublicHttpPort>$PORT</PublicHttpPort>
+  <PublicHttpsPort>$((PORT + 1))</PublicHttpsPort>
+  <EnableHttps>false</EnableHttps>
+</NetworkConfiguration>
+EOF
+
+echo "==> starting jellyfin on port $PORT (data: $TMPDIR)"
+nix shell nixpkgs#jellyfin --command jellyfin \
+  --datadir "$TMPDIR/data" \
+  --configdir "$TMPDIR/config" \
+  --cachedir "$TMPDIR/cache" \
+  --logdir "$TMPDIR/log" \
+  --nowebclient \
+  >"$JF_LOG" 2>&1 &
+JF_PID=$!
+
+echo "==> waiting for jellyfin startup complete..."
+for i in $(seq 1 120); do
+  if grep -q "Startup complete" "$JF_LOG" 2>/dev/null; then
+    echo "==> jellyfin fully started after ${i}s"
+    break
+  fi
+  if ! kill -0 "$JF_PID" 2>/dev/null; then
+    echo "==> jellyfin process died, logs:"
+    cat "$JF_LOG"
+    exit 1
+  fi
+  sleep 1
+done
+
+if ! grep -q "Startup complete" "$JF_LOG" 2>/dev/null; then
+  echo "==> timed out waiting for jellyfin"
+  cat "$JF_LOG"
+  exit 1
+fi
+
+STATUS=$(curl -sf "$BASE_URL/System/Info/Public")
+echo "==> $(echo "$STATUS" | grep -o '"StartupWizardCompleted":[a-z]*')"
+
+echo "==> writing test config"
+cat > "$TMPDIR/config.yml" <<EOF
+version: 1
+base_url: "$BASE_URL"
+system: {}
+startup:
+  serverName: "test-jellyfin"
+  preferredMetadataLanguage: "en"
+  metadataCountryCode: "US"
+  uiCulture: "en-US"
+  remoteAccess:
+    enableRemoteAccess: true
+    enableAutomaticPortMapping: false
+  user:
+    name: "admin"
+    password: "testpass123"
+  apiKeyApp: "jellarr"
+  apiKeyFile: "$TMPDIR/api-key"
+  completeStartupWizard: true
+users:
+  - name: "admin"
+    password: "testpass123"
+    policy:
+      isAdministrator: true
+EOF
+
+echo "==> running jellarr"
+npx tsx src/cli/index.ts apply --configFile "$TMPDIR/config.yml" || true
+
+echo ""
+echo "==> jellyfin logs around the error:"
+grep -A3 "InvalidOperationException\|Startup/User\|500\|error" "$JF_LOG" | tail -20
+
+echo ""
+echo "==> results:"
+echo "  wizard: $(curl -sf "$BASE_URL/System/Info/Public" | grep -o '"StartupWizardCompleted":[a-z]*')"
+echo "  api key file: $(cat "$TMPDIR/api-key" 2>/dev/null || echo 'MISSING')"
+
+API_KEY=$(cat "$TMPDIR/api-key")
+USERS=$(curl -sf -H "X-Emby-Token: $API_KEY" "$BASE_URL/Users")
+echo "  users: $(echo "$USERS" | head -c 200)"
+echo ""
+echo ""
+echo "==> success!"

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,7 +1,7 @@
 import createClient, { type Client } from "openapi-fetch";
 import type { paths } from "../../generated/schema";
 
-export function makeClient(baseUrl: string, apiKey: string): Client<paths> {
+export function makeClient(baseUrl: string, apiKey?: string): Client<paths> {
   const client: Client<paths> = createClient<paths>({
     baseUrl: baseUrl.replace(/\/+$/, ""),
   });
@@ -9,7 +9,9 @@ export function makeClient(baseUrl: string, apiKey: string): Client<paths> {
   client.use({
     onRequest({ request }: { request: Request }): Request {
       const headers: Headers = new Headers(request.headers);
-      headers.set("X-Emby-Token", apiKey);
+      if (apiKey) {
+        headers.set("X-Emby-Token", apiKey);
+      }
       headers.set(
         "X-Emby-Authorization",
         'MediaBrowser Client="jellarr", Device="cli", Version="0.1.0"',

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -14,7 +14,7 @@ export function makeClient(baseUrl: string, apiKey?: string): Client<paths> {
       }
       headers.set(
         "X-Emby-Authorization",
-        'MediaBrowser Client="jellarr", Device="cli", Version="0.1.0"',
+        'MediaBrowser Client="jellarr", Device="cli", DeviceId="jellarr-cli", Version="0.1.0"',
       );
       return new Request(request, { headers });
     },

--- a/src/api/jellyfin.types.ts
+++ b/src/api/jellyfin.types.ts
@@ -42,6 +42,9 @@ export type GetUsersResponse = ApiResponse<UserDtoSchema[]>;
 export type PostNewUserResponse = ApiResponse<UserDtoSchema>;
 export type PostUserPolicyResponse = ApiResponse<void>;
 export type PostStartupCompleteResponse = ApiResponse<void>;
+export type GetStartupUserResponse = ApiResponse<{
+  Name?: string | null;
+}>;
 export type PostStartupConfigurationResponse = ApiResponse<void>;
 export type PostStartupUserResponse = ApiResponse<void>;
 export type PostStartupRemoteAccessResponse = ApiResponse<void>;
@@ -82,6 +85,7 @@ export interface JellyfinClient {
   createUser(body: CreateUserByNameSchema): Promise<void>;
   updateUserPolicy(userId: string, body: UserPolicySchema): Promise<void>;
   completeStartupWizard(): Promise<void>;
+  getStartupUser(): Promise<void>;
   updateStartupConfiguration(
     body: StartupConfigurationDtoSchema,
   ): Promise<void>;

--- a/src/api/jellyfin.types.ts
+++ b/src/api/jellyfin.types.ts
@@ -15,6 +15,13 @@ import {
   type PluginInfoSchema,
   type BasePluginConfigurationSchema,
 } from "../types/schema/plugins";
+import type {
+  StartupConfigurationDtoSchema,
+  StartupUserDtoSchema,
+  StartupRemoteAccessDtoSchema,
+  AuthenticationResultSchema,
+  AuthenticationInfoSchema,
+} from "../types/schema/startup";
 
 export interface ApiResponse<T = unknown> {
   data?: T;
@@ -35,6 +42,17 @@ export type GetUsersResponse = ApiResponse<UserDtoSchema[]>;
 export type PostNewUserResponse = ApiResponse<UserDtoSchema>;
 export type PostUserPolicyResponse = ApiResponse<void>;
 export type PostStartupCompleteResponse = ApiResponse<void>;
+export type PostStartupConfigurationResponse = ApiResponse<void>;
+export type PostStartupUserResponse = ApiResponse<void>;
+export type PostStartupRemoteAccessResponse = ApiResponse<void>;
+export type PostAuthenticateByNameResponse =
+  ApiResponse<AuthenticationResultSchema>;
+export type PostCreateKeyResponse = ApiResponse<void>;
+export type GetKeysResponse = ApiResponse<{
+  Items?: AuthenticationInfoSchema[];
+  TotalRecordCount?: number;
+  StartIndex?: number;
+}>;
 export type GetPluginsResponse = ApiResponse<PluginInfoSchema[]>;
 export type PostInstallPackageResponse = ApiResponse<void>;
 export type GetPluginConfigurationResponse =
@@ -64,6 +82,14 @@ export interface JellyfinClient {
   createUser(body: CreateUserByNameSchema): Promise<void>;
   updateUserPolicy(userId: string, body: UserPolicySchema): Promise<void>;
   completeStartupWizard(): Promise<void>;
+  updateStartupConfiguration(
+    body: StartupConfigurationDtoSchema,
+  ): Promise<void>;
+  updateStartupUser(body: StartupUserDtoSchema): Promise<void>;
+  setRemoteAccess(body: StartupRemoteAccessDtoSchema): Promise<void>;
+  authenticateByName(username: string, password: string): Promise<string>;
+  createApiKey(app: string): Promise<void>;
+  getApiKeys(): Promise<AuthenticationInfoSchema[]>;
   getPlugins(): Promise<PluginInfoSchema[]>;
   installPackage(name: string): Promise<void>;
   getPluginConfiguration(

--- a/src/api/jellyfin_client.ts
+++ b/src/api/jellyfin_client.ts
@@ -25,6 +25,7 @@ import type {
   PostNewUserResponse,
   PostUserPolicyResponse,
   PostStartupCompleteResponse,
+  GetStartupUserResponse,
   PostStartupConfigurationResponse,
   PostStartupUserResponse,
   PostStartupRemoteAccessResponse,
@@ -253,6 +254,16 @@ export function createJellyfinClient(
       if (res.error) {
         throw new Error(
           `POST /Startup/Complete failed: ${res.response.status.toString()}`,
+        );
+      }
+    },
+
+    async getStartupUser(): Promise<void> {
+      const res: GetStartupUserResponse = await client.GET("/Startup/User");
+
+      if (res.error) {
+        throw new Error(
+          `GET /Startup/User failed: ${res.response.status.toString()}`,
         );
       }
     },

--- a/src/api/jellyfin_client.ts
+++ b/src/api/jellyfin_client.ts
@@ -25,6 +25,12 @@ import type {
   PostNewUserResponse,
   PostUserPolicyResponse,
   PostStartupCompleteResponse,
+  PostStartupConfigurationResponse,
+  PostStartupUserResponse,
+  PostStartupRemoteAccessResponse,
+  PostAuthenticateByNameResponse,
+  PostCreateKeyResponse,
+  GetKeysResponse,
   GetPluginsResponse,
   PostInstallPackageResponse,
   GetPluginConfigurationResponse,
@@ -37,10 +43,16 @@ import {
   type PluginInfoSchema,
   type BasePluginConfigurationSchema,
 } from "../types/schema/plugins";
+import type {
+  StartupConfigurationDtoSchema,
+  StartupUserDtoSchema,
+  StartupRemoteAccessDtoSchema,
+  AuthenticationInfoSchema,
+} from "../types/schema/startup";
 
 export function createJellyfinClient(
   baseUrl: string,
-  apiKey: string,
+  apiKey?: string,
 ): JellyfinClient {
   const client: Client<paths> = makeClient(baseUrl, apiKey);
 
@@ -243,6 +255,105 @@ export function createJellyfinClient(
           `POST /Startup/Complete failed: ${res.response.status.toString()}`,
         );
       }
+    },
+
+    async updateStartupConfiguration(
+      body: StartupConfigurationDtoSchema,
+    ): Promise<void> {
+      const res: PostStartupConfigurationResponse = await client.POST(
+        "/Startup/Configuration",
+        {
+          body,
+          headers: { "content-type": "application/json" },
+        },
+      );
+
+      if (res.error) {
+        throw new Error(
+          `POST /Startup/Configuration failed: ${res.response.status.toString()}`,
+        );
+      }
+    },
+
+    async updateStartupUser(body: StartupUserDtoSchema): Promise<void> {
+      const res: PostStartupUserResponse = await client.POST("/Startup/User", {
+        body,
+        headers: { "content-type": "application/json" },
+      });
+
+      if (res.error) {
+        throw new Error(
+          `POST /Startup/User failed: ${res.response.status.toString()}`,
+        );
+      }
+    },
+
+    async setRemoteAccess(body: StartupRemoteAccessDtoSchema): Promise<void> {
+      const res: PostStartupRemoteAccessResponse = await client.POST(
+        "/Startup/RemoteAccess",
+        {
+          body,
+          headers: { "content-type": "application/json" },
+        },
+      );
+
+      if (res.error) {
+        throw new Error(
+          `POST /Startup/RemoteAccess failed: ${res.response.status.toString()}`,
+        );
+      }
+    },
+
+    async authenticateByName(
+      username: string,
+      password: string,
+    ): Promise<string> {
+      const res: PostAuthenticateByNameResponse = await client.POST(
+        "/Users/AuthenticateByName",
+        {
+          body: { Username: username, Pw: password },
+          headers: { "content-type": "application/json" },
+        },
+      );
+
+      if (res.error) {
+        throw new Error(
+          `POST /Users/AuthenticateByName failed: ${res.response.status.toString()}`,
+        );
+      }
+
+      const accessToken: string | null | undefined = res.data?.AccessToken;
+      if (!accessToken) {
+        throw new Error(
+          "POST /Users/AuthenticateByName succeeded but returned no AccessToken",
+        );
+      }
+
+      return accessToken;
+    },
+
+    async createApiKey(app: string): Promise<void> {
+      const res: PostCreateKeyResponse = await client.POST("/Auth/Keys", {
+        params: { query: { app } },
+      });
+
+      if (res.error) {
+        throw new Error(
+          `POST /Auth/Keys failed: ${res.response.status.toString()}`,
+        );
+      }
+    },
+
+    async getApiKeys(): Promise<AuthenticationInfoSchema[]> {
+      const res: GetKeysResponse = await client.GET("/Auth/Keys");
+
+      if (res.error) {
+        throw new Error(
+          `GET /Auth/Keys failed: ${res.response.status.toString()}`,
+        );
+      }
+
+      return (res.data?.Items ?? []) as AuthenticationInfoSchema[];
     },
 
     async getPlugins(): Promise<PluginInfoSchema[]> {

--- a/src/apply/library.ts
+++ b/src/apply/library.ts
@@ -1,5 +1,4 @@
 import { logger } from "../lib/logger";
-import { ChangeSetBuilder } from "../lib/changeset";
 import type { JellyfinClient } from "../api/jellyfin.types";
 import type { VirtualFolderConfig } from "../types/config/library";
 import type {
@@ -11,7 +10,6 @@ import {
   mapVirtualFolderConfigToSchema,
   mapVirtualFolderInfoSchemaToAddVirtualFolderDtoSchema,
 } from "../mappers/library";
-import { applyChangeset, diff, type IChange } from "json-diff-ts";
 
 export function calculateLibraryDiff(
   current: VirtualFolderInfoSchema[],
@@ -21,27 +19,29 @@ export function calculateLibraryDiff(
     return undefined;
   }
 
-  const next: VirtualFolderInfoSchema[] = desired.map(
-    mapVirtualFolderConfigToSchema,
+  const currentNames: Set<string> = new Set(
+    current
+      .map((f: VirtualFolderInfoSchema) => f.Name)
+      .filter((n): n is string => n !== undefined && n !== null),
   );
 
-  const patch: IChange[] = new ChangeSetBuilder(
-    diff(current, next, {
-      embeddedObjKeys: { ".": "Name" },
-      treatTypeChangeAsReplace: false,
-    }),
-  )
-    .atomize()
-    .withoutRemoves()
-    .withoutUpdates()
-    .toArray();
+  const foldersToCreate: VirtualFolderInfoSchema[] = desired
+    .filter(
+      (d: VirtualFolderConfig) => !currentNames.has(d.name),
+    )
+    .map(mapVirtualFolderConfigToSchema);
 
-  if (patch.length !== 0) {
-    logger.info(JSON.stringify(patch));
-    return applyChangeset([], patch) as VirtualFolderInfoSchema[];
+  if (foldersToCreate.length === 0) {
+    return undefined;
   }
 
-  return undefined;
+  logger.info(
+    JSON.stringify(
+      foldersToCreate.map((f: VirtualFolderInfoSchema) => f.Name),
+    ),
+  );
+
+  return foldersToCreate;
 }
 
 export async function applyLibrary(

--- a/src/apply/startup.ts
+++ b/src/apply/startup.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync, mkdirSync } from "fs";
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
 import { dirname } from "path";
 import type { StartupConfig } from "../types/config/startup";
 import { createJellyfinClient } from "../api/jellyfin_client";
@@ -16,10 +16,22 @@ function resolvePassword(config: {
   return "";
 }
 
+function readExistingApiKey(apiKeyFile: string | undefined): string | undefined {
+  if (!apiKeyFile || !existsSync(apiKeyFile)) return undefined;
+  const content: string = readFileSync(apiKeyFile, "utf8").trim();
+  return content.length > 0 ? content : undefined;
+}
+
 export async function applyStartupWizard(
   baseUrl: string,
   startup: StartupConfig,
 ): Promise<string> {
+  const existingKey: string | undefined = readExistingApiKey(startup.apiKeyFile);
+  if (existingKey) {
+    console.log("✓ startup API key already exists, skipping wizard");
+    return existingKey;
+  }
+
   const unauthClient: JellyfinClient = createJellyfinClient(baseUrl);
 
   if (

--- a/src/apply/startup.ts
+++ b/src/apply/startup.ts
@@ -50,16 +50,6 @@ export async function applyStartupWizard(
     console.log("✓ configured startup server settings");
   }
 
-  if (startup.user) {
-    const password: string = resolvePassword(startup.user);
-    console.log("→ setting startup user");
-    await unauthClient.updateStartupUser({
-      Name: startup.user.name,
-      Password: password,
-    });
-    console.log("✓ set startup user");
-  }
-
   if (startup.remoteAccess) {
     console.log("→ configuring remote access");
     await unauthClient.setRemoteAccess({
@@ -68,6 +58,16 @@ export async function applyStartupWizard(
         startup.remoteAccess.enableAutomaticPortMapping,
     });
     console.log("✓ configured remote access");
+  }
+
+  if (startup.user) {
+    const password: string = resolvePassword(startup.user);
+    console.log("→ setting startup user");
+    await unauthClient.updateStartupUser({
+      Name: startup.user.name,
+      Password: password,
+    });
+    console.log("✓ set startup user");
   }
 
   if (startup.completeStartupWizard) {

--- a/src/apply/startup.ts
+++ b/src/apply/startup.ts
@@ -1,0 +1,110 @@
+import { readFileSync, writeFileSync, mkdirSync } from "fs";
+import { dirname } from "path";
+import type { StartupConfig } from "../types/config/startup";
+import { createJellyfinClient } from "../api/jellyfin_client";
+import type { JellyfinClient } from "../api/jellyfin.types";
+import type { AuthenticationInfoSchema } from "../types/schema/startup";
+
+function resolvePassword(config: {
+  password?: string;
+  passwordFile?: string;
+}): string {
+  if (config.password !== undefined) return config.password;
+  if (config.passwordFile !== undefined) {
+    return readFileSync(config.passwordFile, "utf8").trim();
+  }
+  return "";
+}
+
+export async function applyStartupWizard(
+  baseUrl: string,
+  startup: StartupConfig,
+): Promise<string> {
+  const unauthClient: JellyfinClient = createJellyfinClient(baseUrl);
+
+  if (
+    startup.serverName !== undefined ||
+    startup.preferredMetadataLanguage !== undefined ||
+    startup.metadataCountryCode !== undefined ||
+    startup.uiCulture !== undefined
+  ) {
+    console.log("→ configuring startup server settings");
+    await unauthClient.updateStartupConfiguration({
+      ServerName: startup.serverName,
+      PreferredMetadataLanguage: startup.preferredMetadataLanguage,
+      MetadataCountryCode: startup.metadataCountryCode,
+      UICulture: startup.uiCulture,
+    });
+    console.log("✓ configured startup server settings");
+  }
+
+  if (startup.user) {
+    const password: string = resolvePassword(startup.user);
+    console.log("→ setting startup user");
+    await unauthClient.updateStartupUser({
+      Name: startup.user.name,
+      Password: password,
+    });
+    console.log("✓ set startup user");
+  }
+
+  if (startup.remoteAccess) {
+    console.log("→ configuring remote access");
+    await unauthClient.setRemoteAccess({
+      EnableRemoteAccess: startup.remoteAccess.enableRemoteAccess,
+      EnableAutomaticPortMapping:
+        startup.remoteAccess.enableAutomaticPortMapping,
+    });
+    console.log("✓ configured remote access");
+  }
+
+  if (startup.completeStartupWizard) {
+    console.log("→ marking startup wizard as complete");
+    await unauthClient.completeStartupWizard();
+    console.log("✓ marked startup wizard as complete");
+  }
+
+  if (!startup.user || !startup.apiKeyApp) {
+    throw new Error(
+      "startup.user and startup.apiKeyApp are required to create an API key",
+    );
+  }
+
+  const password: string = resolvePassword(startup.user);
+  console.log("→ authenticating as startup user");
+  const accessToken: string = await unauthClient.authenticateByName(
+    startup.user.name,
+    password,
+  );
+  console.log("✓ authenticated as startup user");
+
+  const authedClient: JellyfinClient = createJellyfinClient(
+    baseUrl,
+    accessToken,
+  );
+
+  console.log("→ creating API key");
+  await authedClient.createApiKey(startup.apiKeyApp);
+
+  const keys: AuthenticationInfoSchema[] = await authedClient.getApiKeys();
+  const createdKey: AuthenticationInfoSchema | undefined = keys.find(
+    (k: AuthenticationInfoSchema) => k.AppName === startup.apiKeyApp,
+  );
+
+  if (!createdKey?.AccessToken) {
+    throw new Error(
+      `Failed to retrieve API key for app "${startup.apiKeyApp}" after creation`,
+    );
+  }
+
+  const apiKey: string = createdKey.AccessToken;
+  console.log("✓ created API key");
+
+  if (startup.apiKeyFile) {
+    mkdirSync(dirname(startup.apiKeyFile), { recursive: true });
+    writeFileSync(startup.apiKeyFile, apiKey, { mode: 0o600 });
+    console.log(`✓ wrote API key to ${startup.apiKeyFile}`);
+  }
+
+  return apiKey;
+}

--- a/src/apply/startup.ts
+++ b/src/apply/startup.ts
@@ -16,7 +16,9 @@ function resolvePassword(config: {
   return "";
 }
 
-function readExistingApiKey(apiKeyFile: string | undefined): string | undefined {
+function readExistingApiKey(
+  apiKeyFile: string | undefined,
+): string | undefined {
   if (!apiKeyFile || !existsSync(apiKeyFile)) return undefined;
   const content: string = readFileSync(apiKeyFile, "utf8").trim();
   return content.length > 0 ? content : undefined;
@@ -26,7 +28,9 @@ export async function applyStartupWizard(
   baseUrl: string,
   startup: StartupConfig,
 ): Promise<string> {
-  const existingKey: string | undefined = readExistingApiKey(startup.apiKeyFile);
+  const existingKey: string | undefined = readExistingApiKey(
+    startup.apiKeyFile,
+  );
   if (existingKey) {
     console.log("✓ startup API key already exists, skipping wizard");
     return existingKey;
@@ -61,6 +65,7 @@ export async function applyStartupWizard(
   }
 
   if (startup.user) {
+    await unauthClient.getStartupUser();
     const password: string = resolvePassword(startup.user);
     console.log("→ setting startup user");
     await unauthClient.updateStartupUser({

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -38,6 +38,7 @@ import {
   getPluginConfigurationSchemaByName,
 } from "../apply/plugins";
 import type { PluginConfig } from "../types/config/plugins";
+import { applyStartupWizard } from "../apply/startup";
 
 export async function runPipeline(path: string): Promise<void> {
   const raw: string = await fs.readFile(path, "utf8");
@@ -53,7 +54,15 @@ export async function runPipeline(path: string): Promise<void> {
 
   const cfg: RootConfig = validationResult.data;
 
-  const apiKey: string | undefined = process.env.JELLARR_API_KEY;
+  const needsStartupWizard: boolean =
+    cfg.startup?.user !== undefined && cfg.startup?.apiKeyApp !== undefined;
+
+  let apiKey: string | undefined = process.env.JELLARR_API_KEY;
+
+  if (needsStartupWizard && cfg.startup) {
+    apiKey = await applyStartupWizard(cfg.base_url, cfg.startup);
+  }
+
   if (!apiKey) throw new Error("JELLARR_API_KEY required");
 
   const jellyfinClient: JellyfinClient = createJellyfinClient(
@@ -191,7 +200,7 @@ export async function runPipeline(path: string): Promise<void> {
     }
   }
 
-  if (cfg.startup?.completeStartupWizard) {
+  if (!needsStartupWizard && cfg.startup?.completeStartupWizard) {
     console.log("→ marking startup wizard as complete");
     await jellyfinClient.completeStartupWizard();
     console.log("✓ marked startup wizard as complete");

--- a/src/types/config/startup.ts
+++ b/src/types/config/startup.ts
@@ -1,9 +1,49 @@
 import { z } from "zod";
 
-export const StartupConfigType: z.ZodObject<{
-  completeStartupWizard: z.ZodOptional<z.ZodBoolean>;
-}> = z
+export const StartupRemoteAccessConfigType = z
   .object({
+    enableRemoteAccess: z.boolean(),
+    enableAutomaticPortMapping: z.boolean(),
+  })
+  .strict();
+
+export type StartupRemoteAccessConfig = z.infer<
+  typeof StartupRemoteAccessConfigType
+>;
+
+export const StartupUserConfigType = z
+  .object({
+    name: z.string().min(1, "User name is required"),
+    password: z.string().optional(),
+    passwordFile: z.string().optional(),
+  })
+  .strict()
+  .refine(
+    (data: { password?: string; passwordFile?: string }) => {
+      const hasPassword: boolean =
+        data.password !== undefined && data.password.trim() !== "";
+      const hasPasswordFile: boolean =
+        data.passwordFile !== undefined && data.passwordFile.trim() !== "";
+      return hasPassword !== hasPasswordFile;
+    },
+    {
+      message: "Must specify exactly one of 'password' or 'passwordFile'",
+      path: [],
+    },
+  );
+
+export type StartupUserConfig = z.infer<typeof StartupUserConfigType>;
+
+export const StartupConfigType = z
+  .object({
+    serverName: z.string().optional(),
+    preferredMetadataLanguage: z.string().optional(),
+    metadataCountryCode: z.string().optional(),
+    uiCulture: z.string().optional(),
+    remoteAccess: StartupRemoteAccessConfigType.optional(),
+    user: StartupUserConfigType.optional(),
+    apiKeyApp: z.string().optional(),
+    apiKeyFile: z.string().optional(),
     completeStartupWizard: z.boolean().optional(),
   })
   .strict();

--- a/src/types/schema/startup.ts
+++ b/src/types/schema/startup.ts
@@ -1,0 +1,15 @@
+import type { components } from "../../../generated/schema";
+
+export type StartupConfigurationDtoSchema =
+  components["schemas"]["StartupConfigurationDto"];
+export type StartupUserDtoSchema = components["schemas"]["StartupUserDto"];
+export type StartupRemoteAccessDtoSchema =
+  components["schemas"]["StartupRemoteAccessDto"];
+export type AuthenticateUserByNameSchema =
+  components["schemas"]["AuthenticateUserByName"];
+export type AuthenticationResultSchema =
+  components["schemas"]["AuthenticationResult"];
+export type AuthenticationInfoSchema =
+  components["schemas"]["AuthenticationInfo"];
+export type AuthenticationInfoQueryResultSchema =
+  components["schemas"]["AuthenticationInfoQueryResult"];

--- a/tests/api/jellyfin_client.spec.ts
+++ b/tests/api/jellyfin_client.spec.ts
@@ -956,3 +956,341 @@ describe("api/jf Plugins façade", () => {
     ).rejects.toThrow(/POST \/Plugins\/plugin-id-123\/Configuration failed/i);
   });
 });
+
+describe("api/jf Startup Configuration façade", () => {
+  beforeEach((): void => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  afterEach((): void => {
+    vi.restoreAllMocks();
+  });
+
+  it("when POST /Startup/Configuration succeeds then it sends JSON body and resolves", async (): Promise<void> => {
+    // Arrange
+    mockFetchNoContent(204);
+
+    // Act
+    const jellyfinClient: JellyfinClient = createJellyfinClient(
+      baseUrl,
+      apiKey,
+    );
+    await jellyfinClient.updateStartupConfiguration({
+      ServerName: "My Jellyfin",
+      UICulture: "en-US",
+    });
+
+    // Assert
+    const req: Request = getLastRequest();
+    expect(req.method).toBe("POST");
+    expect(req.url).toMatch(/\/Startup\/Configuration$/);
+    expect(req.headers.get("content-type")).toBe("application/json");
+
+    const bodyText: string = await req.text();
+    expect(bodyText).toContain("My Jellyfin");
+    expect(bodyText).toContain("en-US");
+  });
+
+  it("when POST /Startup/Configuration fails then it throws an error with status", async (): Promise<void> => {
+    // Arrange
+    fetchMock = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(new Response("boom", { status: 500 }));
+
+    // Act
+    const jellyfinClient: JellyfinClient = createJellyfinClient(
+      baseUrl,
+      apiKey,
+    );
+
+    // Assert
+    await expect(
+      jellyfinClient.updateStartupConfiguration({ ServerName: "test" }),
+    ).rejects.toThrow(/POST \/Startup\/Configuration failed/i);
+  });
+});
+
+describe("api/jf Startup User façade", () => {
+  beforeEach((): void => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  afterEach((): void => {
+    vi.restoreAllMocks();
+  });
+
+  it("when POST /Startup/User succeeds then it sends JSON body and resolves", async (): Promise<void> => {
+    // Arrange
+    mockFetchNoContent(204);
+
+    // Act
+    const jellyfinClient: JellyfinClient = createJellyfinClient(
+      baseUrl,
+      apiKey,
+    );
+    await jellyfinClient.updateStartupUser({
+      Name: "admin",
+      Password: "secret",
+    });
+
+    // Assert
+    const req: Request = getLastRequest();
+    expect(req.method).toBe("POST");
+    expect(req.url).toMatch(/\/Startup\/User$/);
+    expect(req.headers.get("content-type")).toBe("application/json");
+
+    const bodyText: string = await req.text();
+    expect(bodyText).toContain("admin");
+    expect(bodyText).toContain("secret");
+  });
+
+  it("when POST /Startup/User fails then it throws an error with status", async (): Promise<void> => {
+    // Arrange
+    fetchMock = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(new Response("boom", { status: 500 }));
+
+    // Act
+    const jellyfinClient: JellyfinClient = createJellyfinClient(
+      baseUrl,
+      apiKey,
+    );
+
+    // Assert
+    await expect(
+      jellyfinClient.updateStartupUser({ Name: "admin", Password: "secret" }),
+    ).rejects.toThrow(/POST \/Startup\/User failed/i);
+  });
+});
+
+describe("api/jf Remote Access façade", () => {
+  beforeEach((): void => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  afterEach((): void => {
+    vi.restoreAllMocks();
+  });
+
+  it("when POST /Startup/RemoteAccess succeeds then it sends JSON body and resolves", async (): Promise<void> => {
+    // Arrange
+    mockFetchNoContent(204);
+
+    // Act
+    const jellyfinClient: JellyfinClient = createJellyfinClient(
+      baseUrl,
+      apiKey,
+    );
+    await jellyfinClient.setRemoteAccess({
+      EnableRemoteAccess: true,
+      EnableAutomaticPortMapping: false,
+    });
+
+    // Assert
+    const req: Request = getLastRequest();
+    expect(req.method).toBe("POST");
+    expect(req.url).toMatch(/\/Startup\/RemoteAccess$/);
+    expect(req.headers.get("content-type")).toBe("application/json");
+
+    const bodyText: string = await req.text();
+    expect(bodyText).toContain("EnableRemoteAccess");
+  });
+
+  it("when POST /Startup/RemoteAccess fails then it throws an error with status", async (): Promise<void> => {
+    // Arrange
+    fetchMock = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(new Response("boom", { status: 500 }));
+
+    // Act
+    const jellyfinClient: JellyfinClient = createJellyfinClient(
+      baseUrl,
+      apiKey,
+    );
+
+    // Assert
+    await expect(
+      jellyfinClient.setRemoteAccess({
+        EnableRemoteAccess: true,
+        EnableAutomaticPortMapping: false,
+      }),
+    ).rejects.toThrow(/POST \/Startup\/RemoteAccess failed/i);
+  });
+});
+
+describe("api/jf Authenticate façade", () => {
+  beforeEach((): void => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  afterEach((): void => {
+    vi.restoreAllMocks();
+  });
+
+  it("when POST /Users/AuthenticateByName succeeds then it returns the access token", async (): Promise<void> => {
+    // Arrange
+    mockFetchJson({
+      AccessToken: "returned-token-123",
+      User: { Id: "user-id", Name: "admin" },
+    });
+
+    // Act
+    const jellyfinClient: JellyfinClient = createJellyfinClient(
+      baseUrl,
+      apiKey,
+    );
+    const token: string = await jellyfinClient.authenticateByName(
+      "admin",
+      "secret",
+    );
+
+    // Assert
+    expect(token).toBe("returned-token-123");
+
+    const req: Request = getLastRequest();
+    expect(req.method).toBe("POST");
+    expect(req.url).toMatch(/\/Users\/AuthenticateByName$/);
+    expect(req.headers.get("content-type")).toBe("application/json");
+
+    const bodyText: string = await req.text();
+    expect(bodyText).toContain("admin");
+    expect(bodyText).toContain("secret");
+  });
+
+  it("when POST /Users/AuthenticateByName fails then it throws an error with status", async (): Promise<void> => {
+    // Arrange
+    fetchMock = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(new Response("boom", { status: 401 }));
+
+    // Act
+    const jellyfinClient: JellyfinClient = createJellyfinClient(
+      baseUrl,
+      apiKey,
+    );
+
+    // Assert
+    await expect(
+      jellyfinClient.authenticateByName("admin", "wrong"),
+    ).rejects.toThrow(/POST \/Users\/AuthenticateByName failed/i);
+  });
+
+  it("when POST /Users/AuthenticateByName returns no AccessToken then it throws", async (): Promise<void> => {
+    // Arrange
+    mockFetchJson({
+      User: { Id: "user-id", Name: "admin" },
+    });
+
+    // Act
+    const jellyfinClient: JellyfinClient = createJellyfinClient(
+      baseUrl,
+      apiKey,
+    );
+
+    // Assert
+    await expect(
+      jellyfinClient.authenticateByName("admin", "secret"),
+    ).rejects.toThrow(/returned no AccessToken/i);
+  });
+});
+
+describe("api/jf API Keys façade", () => {
+  beforeEach((): void => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  afterEach((): void => {
+    vi.restoreAllMocks();
+  });
+
+  it("when POST /Auth/Keys succeeds then it sends app query param and resolves", async (): Promise<void> => {
+    // Arrange
+    mockFetchNoContent(204);
+
+    // Act
+    const jellyfinClient: JellyfinClient = createJellyfinClient(
+      baseUrl,
+      apiKey,
+    );
+    await jellyfinClient.createApiKey("jellarr");
+
+    // Assert
+    const req: Request = getLastRequest();
+    expect(req.method).toBe("POST");
+    expect(req.url).toMatch(/\/Auth\/Keys\?app=jellarr/);
+    expect(req.headers.get("X-Emby-Token")).toBe(apiKey);
+  });
+
+  it("when POST /Auth/Keys fails then it throws an error with status", async (): Promise<void> => {
+    // Arrange
+    fetchMock = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(new Response("boom", { status: 401 }));
+
+    // Act
+    const jellyfinClient: JellyfinClient = createJellyfinClient(
+      baseUrl,
+      apiKey,
+    );
+
+    // Assert
+    await expect(jellyfinClient.createApiKey("jellarr")).rejects.toThrow(
+      /POST \/Auth\/Keys failed/i,
+    );
+  });
+
+  it("when GET /Auth/Keys returns JSON then it returns the items array", async (): Promise<void> => {
+    // Arrange
+    const payload = {
+      Items: [
+        {
+          Id: 1,
+          AccessToken: "token-abc",
+          AppName: "jellarr",
+        },
+      ],
+      TotalRecordCount: 1,
+      StartIndex: 0,
+    };
+    mockFetchJson(payload);
+
+    // Act
+    const jellyfinClient: JellyfinClient = createJellyfinClient(
+      baseUrl,
+      apiKey,
+    );
+    const keys = await jellyfinClient.getApiKeys();
+
+    // Assert
+    expect(keys).toHaveLength(1);
+    expect(keys[0]?.AccessToken).toBe("token-abc");
+    expect(keys[0]?.AppName).toBe("jellarr");
+
+    const req: Request = getLastRequest();
+    expect(req.method).toBe("GET");
+    expect(req.url).toMatch(/\/Auth\/Keys$/);
+  });
+
+  it("when GET /Auth/Keys fails then it throws an error with status", async (): Promise<void> => {
+    // Arrange
+    fetchMock = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(new Response("boom", { status: 403 }));
+
+    // Act
+    const jellyfinClient: JellyfinClient = createJellyfinClient(
+      baseUrl,
+      apiKey,
+    );
+
+    // Assert
+    await expect(jellyfinClient.getApiKeys()).rejects.toThrow(
+      /GET \/Auth\/Keys failed/i,
+    );
+  });
+});

--- a/tests/types/config/startup.spec.ts
+++ b/tests/types/config/startup.spec.ts
@@ -98,4 +98,156 @@ describe("StartupConfig", () => {
       expect(strictError?.code).toBe("unrecognized_keys");
     }
   });
+
+  it("should validate full startup config with all fields", () => {
+    // Arrange
+    const validConfig: z.input<typeof StartupConfigType> = {
+      serverName: "My Jellyfin",
+      preferredMetadataLanguage: "en",
+      metadataCountryCode: "US",
+      uiCulture: "en-US",
+      remoteAccess: {
+        enableRemoteAccess: true,
+        enableAutomaticPortMapping: false,
+      },
+      user: {
+        name: "admin",
+        password: "secret",
+      },
+      apiKeyApp: "jellarr",
+      apiKeyFile: "/run/jellarr/api-key",
+      completeStartupWizard: true,
+    };
+
+    // Act
+    const result: ZodSafeParseResult<StartupConfig> =
+      StartupConfigType.safeParse(validConfig);
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.serverName).toBe("My Jellyfin");
+      expect(result.data.preferredMetadataLanguage).toBe("en");
+      expect(result.data.metadataCountryCode).toBe("US");
+      expect(result.data.uiCulture).toBe("en-US");
+      expect(result.data.remoteAccess?.enableRemoteAccess).toBe(true);
+      expect(result.data.remoteAccess?.enableAutomaticPortMapping).toBe(false);
+      expect(result.data.user?.name).toBe("admin");
+      expect(result.data.user?.password).toBe("secret");
+      expect(result.data.apiKeyApp).toBe("jellarr");
+      expect(result.data.apiKeyFile).toBe("/run/jellarr/api-key");
+      expect(result.data.completeStartupWizard).toBe(true);
+    }
+  });
+
+  it("should validate startup user with passwordFile", () => {
+    // Arrange
+    const validConfig: z.input<typeof StartupConfigType> = {
+      user: {
+        name: "admin",
+        passwordFile: "/run/secrets/admin-pw",
+      },
+    };
+
+    // Act
+    const result: ZodSafeParseResult<StartupConfig> =
+      StartupConfigType.safeParse(validConfig);
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.user?.name).toBe("admin");
+      expect(result.data.user?.passwordFile).toBe("/run/secrets/admin-pw");
+    }
+  });
+
+  it("should reject startup user with both password and passwordFile", () => {
+    // Arrange
+    const invalidConfig: z.input<typeof StartupConfigType> = {
+      user: {
+        name: "admin",
+        password: "secret",
+        passwordFile: "/run/secrets/admin-pw",
+      },
+    };
+
+    // Act
+    const result: ZodSafeParseResult<StartupConfig> =
+      StartupConfigType.safeParse(invalidConfig);
+
+    // Assert
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject startup user with neither password nor passwordFile", () => {
+    // Arrange
+    const invalidConfig: z.input<typeof StartupConfigType> = {
+      user: {
+        name: "admin",
+      },
+    };
+
+    // Act
+    const result: ZodSafeParseResult<StartupConfig> =
+      StartupConfigType.safeParse(invalidConfig);
+
+    // Assert
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject startup user with empty name", () => {
+    // Arrange
+    const invalidConfig: z.input<typeof StartupConfigType> = {
+      user: {
+        name: "",
+        password: "secret",
+      },
+    };
+
+    // Act
+    const result: ZodSafeParseResult<StartupConfig> =
+      StartupConfigType.safeParse(invalidConfig);
+
+    // Assert
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject remoteAccess with extra fields", () => {
+    // Arrange
+    const invalidConfig = {
+      remoteAccess: {
+        enableRemoteAccess: true,
+        enableAutomaticPortMapping: false,
+        extraField: "not allowed",
+      },
+    };
+
+    // Act
+    const result: ZodSafeParseResult<StartupConfig> =
+      StartupConfigType.safeParse(invalidConfig);
+
+    // Assert
+    expect(result.success).toBe(false);
+  });
+
+  it("should validate config with only server settings", () => {
+    // Arrange
+    const validConfig: z.input<typeof StartupConfigType> = {
+      serverName: "Test Server",
+      uiCulture: "de-DE",
+    };
+
+    // Act
+    const result: ZodSafeParseResult<StartupConfig> =
+      StartupConfigType.safeParse(validConfig);
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.serverName).toBe("Test Server");
+      expect(result.data.uiCulture).toBe("de-DE");
+      expect(result.data.user).toBeUndefined();
+      expect(result.data.remoteAccess).toBeUndefined();
+    }
+  });
 });


### PR DESCRIPTION
fixes: #49

## Summary

- Automate fresh Jellyfin instance initialization using all `/Startup/*` endpoints
- A single jellarr run can now configure server settings, create the initial admin user, set remote access, complete the startup wizard, authenticate, and generate a permanent API key written to a file
- When `startup.user` and `startup.apiKeyApp` are configured, the pipeline runs the startup wizard **before** requiring `JELLARR_API_KEY`, then uses the newly created key for the remaining pipeline steps

### New config options under `startup:`

| Field | Type | Description |
|-------|------|-------------|
| `serverName` | string? | Server name set during startup |
| `preferredMetadataLanguage` | string? | Metadata language |
| `metadataCountryCode` | string? | Metadata country code |
| `uiCulture` | string? | UI language culture |
| `remoteAccess` | object? | `enableRemoteAccess` + `enableAutomaticPortMapping` |
| `user` | object? | `name` + `password`/`passwordFile` (XOR) |
| `apiKeyApp` | string? | App name for the created API key |
| `apiKeyFile` | string? | File path to write the API key to |
| `completeStartupWizard` | bool? | Kept for backwards compat |

### Example config

```yaml
startup:
  serverName: "My Jellyfin"
  preferredMetadataLanguage: "en"
  metadataCountryCode: "US"
  uiCulture: "en-US"
  remoteAccess:
    enableRemoteAccess: true
    enableAutomaticPortMapping: false
  user:
    name: "admin"
    passwordFile: "/run/secrets/admin-pw"
  apiKeyApp: "jellarr"
  apiKeyFile: "/run/jellarr/api-key"
  completeStartupWizard: true
```

### Files changed

- **`src/types/config/startup.ts`** — Expanded Zod schema with all new fields
- **`src/types/schema/startup.ts`** (new) — OpenAPI type aliases for startup/auth DTOs
- **`src/api/client.ts`** — `apiKey` now optional; header only set when provided
- **`src/api/jellyfin.types.ts`** — 6 new response types + interface methods
- **`src/api/jellyfin_client.ts`** — Implemented `updateStartupConfiguration`, `updateStartupUser`, `setRemoteAccess`, `authenticateByName`, `createApiKey`, `getApiKeys`
- **`src/apply/startup.ts`** (new) — `applyStartupWizard()` orchestration
- **`src/pipeline/index.ts`** — Startup runs before API key check
- **`nix/module/types/startup.nix`** — Nix option types for all new fields
- **`nix/tests/module/types/startup.nix`** — 10 new Nix test cases
- **`tests/types/config/startup.spec.ts`** — 12 tests for config validation
- **`tests/api/jellyfin_client.spec.ts`** — Tests for all 6 new client methods

## Test plan

- [x] `npx vitest run` — 417 tests pass
- [x] `npx tsc --noEmit` — clean
- [x] `nix fmt` — formatted
- [x] `nix-build nix/tests/module/types/default.nix` — 124 Nix tests pass
- [x] Manual test against fresh Jellyfin Docker container to verify full flow