### PR TITLE
fix: library diff produces undefined Name when folders already exist

### DIFF
--- a/src/apply/library.ts
+++ b/src/apply/library.ts
@@ -1,5 +1,4 @@
 import { logger } from "../lib/logger";
-import { ChangeSetBuilder } from "../lib/changeset";
 import type { JellyfinClient } from "../api/jellyfin.types";
 import type { VirtualFolderConfig } from "../types/config/library";
 import type {
@@ -11,7 +10,6 @@ import {
   mapVirtualFolderConfigToSchema,
   mapVirtualFolderInfoSchemaToAddVirtualFolderDtoSchema,
 } from "../mappers/library";
-import { applyChangeset, diff, type IChange } from "json-diff-ts";
 
 export function calculateLibraryDiff(
   current: VirtualFolderInfoSchema[],
@@ -21,27 +19,25 @@ export function calculateLibraryDiff(
     return undefined;
   }
 
-  const next: VirtualFolderInfoSchema[] = desired.map(
-    mapVirtualFolderConfigToSchema,
+  const currentNames: Set<string> = new Set(
+    current
+      .map((f: VirtualFolderInfoSchema) => f.Name)
+      .filter((n): n is string => n !== undefined && n !== null),
   );
 
-  const patch: IChange[] = new ChangeSetBuilder(
-    diff(current, next, {
-      embeddedObjKeys: { ".": "Name" },
-      treatTypeChangeAsReplace: false,
-    }),
-  )
-    .atomize()
-    .withoutRemoves()
-    .withoutUpdates()
-    .toArray();
+  const foldersToCreate: VirtualFolderInfoSchema[] = desired
+    .filter((d: VirtualFolderConfig) => !currentNames.has(d.name))
+    .map(mapVirtualFolderConfigToSchema);
 
-  if (patch.length !== 0) {
-    logger.info(JSON.stringify(patch));
-    return applyChangeset([], patch) as VirtualFolderInfoSchema[];
+  if (foldersToCreate.length === 0) {
+    return undefined;
   }
 
-  return undefined;
+  logger.info(
+    JSON.stringify(foldersToCreate.map((f: VirtualFolderInfoSchema) => f.Name)),
+  );
+
+  return foldersToCreate;
 }
 
 export async function applyLibrary(


### PR DESCRIPTION
## Summary

- When virtual folders already existed in Jellyfin and only had new paths to add, the `json-diff-ts` changeset produced sub-object ADD patches for the individual paths
- Applying these patches to an empty array via `applyChangeset([], patch)` lost all parent context (`Name`, `CollectionType`), causing `addVirtualFolder` to receive `undefined` as the folder name → 400 error from Jellyfin
- Replaced the changeset-based diff with a simple name-based filter that returns only folders that don't yet exist, which matches the original intent (`withoutUpdates` filter) without the atomization bug

## Test plan

- [x] All 397 existing tests pass (including 12 library-specific tests)
- [x] Verified manually: when current has folders and desired matches, returns `undefined` (no-op)
- [x] Verified manually: when current is empty and desired has folders, returns the full folder objects with `Name` intact