### PR TITLE
feat: env-var substitution for config secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,11 +386,11 @@ curl -s -H "X-Emby-Token: $API_KEY" \
 
 Any `${VAR}` reference in the config file is replaced with the value of the
 environment variable `VAR` before the YAML is parsed. Because substitution runs
-on the raw text, it works for any value at any depth — including arbitrary
-plugin configuration. This keeps secrets (such as SSO client secrets) out of the
-config file and, for Nix users, out of the world-readable Nix store.
+on the raw text, it works for any value at any depth, including arbitrary plugin
+configuration. This keeps secrets (such as SSO client secrets) out of the config
+file and, for Nix users, out of the world-readable Nix store.
 
-- An **undefined** variable is a hard error — a missing secret fails loudly
+- An **undefined** variable is a hard error: a missing secret fails loudly
   instead of silently substituting an empty string.
 - Write `$$` for a literal dollar sign; `$${VAR}` therefore yields the literal
   text `${VAR}` (no expansion).
@@ -442,10 +442,10 @@ services.jellarr = {
 
 `environmentFile` places the secret in the service's environment, readable via
 `/proc/<pid>/environ` by privileged processes. For stronger isolation, source
-the variable from a systemd credential — materialized into a per-service ramfs
-at `$CREDENTIALS_DIRECTORY`, never on disk or in the global environment — and
-export it just for jellarr via a small wrapper. The `jellarr` package comes from
-the flake input:
+the variable from a systemd credential (materialized into a per-service ramfs at
+`$CREDENTIALS_DIRECTORY`, never on disk or in the global environment) and export
+it just for jellarr via a small wrapper. The `jellarr` package comes from the
+flake input:
 
 ```nix
 let
@@ -462,9 +462,9 @@ in
 }
 ```
 
-jellarr itself only ever reads environment variables — whether they come from an
-`environmentFile` or a credential wrapper is entirely the operator's choice, so
-this works identically on Docker and bare metal.
+jellarr itself only ever reads environment variables; whether they come from an
+`environmentFile` or a credential wrapper is the operator's choice, so this
+works identically on Docker and bare metal.
 
 ### With sops-nix (nix only)
 

--- a/README.md
+++ b/README.md
@@ -382,6 +382,90 @@ curl -s -H "X-Emby-Token: $API_KEY" \
 
 ## Secret Management
 
+### Variable Substitution
+
+Any `${VAR}` reference in the config file is replaced with the value of the
+environment variable `VAR` before the YAML is parsed. Because substitution runs
+on the raw text, it works for any value at any depth — including arbitrary
+plugin configuration. This keeps secrets (such as SSO client secrets) out of the
+config file and, for Nix users, out of the world-readable Nix store.
+
+- An **undefined** variable is a hard error — a missing secret fails loudly
+  instead of silently substituting an empty string.
+- Write `$$` for a literal dollar sign; `$${VAR}` therefore yields the literal
+  text `${VAR}` (no expansion).
+- This applies to every config load: an existing config that contains a literal
+  `${...}` or `$$` must escape it (write `$$` for a literal `$`) after enabling
+  this feature.
+
+```yaml
+plugins:
+  - name: "SSO Authentication"
+    configuration:
+      OidConfigs:
+        kanidm:
+          OidSecret: ${SSO_KANIDM_SECRET} # expanded from the environment at load
+```
+
+Provide the variables via the service's environment. With the NixOS module and
+sops-nix, render an env file with a template and point `environmentFile` at it:
+
+```nix
+sops = {
+  secrets.jellyfin-sso-kanidm = { };
+  templates.jellarr-env = {
+    content = ''
+      JELLARR_API_KEY=${config.sops.placeholder.jellarr-api-key}
+      SSO_KANIDM_SECRET=${config.sops.placeholder.jellyfin-sso-kanidm}
+    '';
+    owner = config.services.jellarr.user;
+    inherit (config.services.jellarr) group;
+  };
+};
+
+services.jellarr = {
+  enable = true;
+  environmentFile = config.sops.templates.jellarr-env.path;
+  config = {
+    base_url = "http://localhost:8096";
+    plugins = [
+      {
+        name = "SSO Authentication";
+        configuration.OidConfigs.kanidm.OidSecret = "\${SSO_KANIDM_SECRET}";
+      }
+    ];
+  };
+};
+```
+
+#### Stronger isolation with systemd credentials (optional)
+
+`environmentFile` places the secret in the service's environment, readable via
+`/proc/<pid>/environ` by privileged processes. For stronger isolation, source
+the variable from a systemd credential — materialized into a per-service ramfs
+at `$CREDENTIALS_DIRECTORY`, never on disk or in the global environment — and
+export it just for jellarr via a small wrapper. The `jellarr` package comes from
+the flake input:
+
+```nix
+let
+  jellarrPkg = inputs.jellarr.packages.${pkgs.stdenv.hostPlatform.system}.default;
+in
+{
+  systemd.services.jellarr.serviceConfig = {
+    LoadCredential = [ "sso-kanidm:${config.sops.secrets.jellyfin-sso-kanidm.path}" ];
+    ExecStart = lib.mkForce (pkgs.writeShellScript "jellarr-start" ''
+      export SSO_KANIDM_SECRET="$(cat "$CREDENTIALS_DIRECTORY/sso-kanidm")"
+      exec ${lib.getExe jellarrPkg}
+    '');
+  };
+}
+```
+
+jellarr itself only ever reads environment variables — whether they come from an
+`environmentFile` or a credential wrapper is entirely the operator's choice, so
+this works identically on Docker and bare metal.
+
 ### With sops-nix (nix only)
 
 ```nix

--- a/src/lib/env-substitution.ts
+++ b/src/lib/env-substitution.ts
@@ -1,0 +1,22 @@
+/**
+ * Expand `${VAR}` references in a raw config string from the given environment.
+ *
+ * Runs on the raw text before YAML parsing, so it applies to any value at any
+ * nesting depth. `$$` is an escape for a literal `$`; therefore `$${VAR}`
+ * produces the literal `${VAR}` rather than expanding it. An undefined variable
+ * is a hard error so missing secrets fail loudly instead of silently emptying.
+ */
+export function substituteEnvVars(
+  raw: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  return raw.replace(/\$\$|\$\{(\w+)\}/g, (match: string, name?: string) => {
+    if (match === "$$") return "$";
+    const varName: string = name as string;
+    const value: string | undefined = env[varName];
+    if (value === undefined) {
+      throw new Error(`Undefined environment variable in config: ${varName}`);
+    }
+    return value;
+  });
+}

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -44,12 +44,14 @@ import {
   getPluginConfigurationSchemaByName,
 } from "../apply/plugins";
 import type { PluginConfig } from "../types/config/plugins";
+import { substituteEnvVars } from "../lib/env-substitution";
 
 export async function runPipeline(path: string): Promise<void> {
   const raw: string = await fs.readFile(path, "utf8");
+  const expanded: string = substituteEnvVars(raw);
 
   const validationResult: ZodSafeParseResult<RootConfig> =
-    RootConfigType.safeParse(YAML.parse(raw));
+    RootConfigType.safeParse(YAML.parse(expanded));
   if (!validationResult.success) {
     const errorMessages: string = validationResult.error.issues
       .map((err: z.core.$ZodIssue) => `${err.path.join(".")}: ${err.message}`)

--- a/tests/lib/env-substitution.spec.ts
+++ b/tests/lib/env-substitution.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { substituteEnvVars } from "../../src/lib/env-substitution";
+
+describe("lib/env-substitution", () => {
+  it("replaces a single ${VAR} with its value", () => {
+    const env: Record<string, string> = { SECRET: "s3cr3t" };
+    const out: string = substituteEnvVars("OidSecret: ${SECRET}", env);
+    expect(out).toBe("OidSecret: s3cr3t");
+  });
+
+  it("replaces multiple and repeated vars", () => {
+    const env: Record<string, string> = { A: "1", B: "2" };
+    expect(substituteEnvVars("${A}-${B}-${A}", env)).toBe("1-2-1");
+  });
+
+  it("expands $$ to a literal $", () => {
+    expect(substituteEnvVars("price is 5$$", {})).toBe("price is 5$");
+  });
+
+  it("treats $${VAR} as a literal ${VAR} (no expansion)", () => {
+    const env: Record<string, string> = { VAR: "expanded" };
+    expect(substituteEnvVars("$${VAR}", env)).toBe("${VAR}");
+  });
+
+  it("handles an expanded var adjacent to an escaped one", () => {
+    const env: Record<string, string> = { A: "1", B: "2" };
+    expect(substituteEnvVars("${A}$${B}", env)).toBe("1${B}");
+  });
+
+  it("throws naming the variable when undefined", () => {
+    expect(() => substituteEnvVars("${MISSING}", {})).toThrowError(/MISSING/);
+  });
+
+  it("returns input unchanged when there is nothing to substitute", () => {
+    expect(substituteEnvVars("plain: value with a lone $ sign", {})).toBe(
+      "plain: value with a lone $ sign",
+    );
+  });
+
+  it("defaults to process.env when env not provided", () => {
+    process.env.JELLARR_TEST_VAR = "fromProcess";
+    try {
+      expect(substituteEnvVars("${JELLARR_TEST_VAR}")).toBe("fromProcess");
+    } finally {
+      delete process.env.JELLARR_TEST_VAR;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds `${VAR}` environment-variable substitution to the config loader so secret values can come from the environment instead of being written into the config file (and, for Nix users, the world-readable Nix store).

- A pure helper, `substituteEnvVars`, expands `${VAR}` in the raw config text before YAML parsing, so it works for any value at any depth, including arbitrary plugin configuration. No schema changes.
- `$$` escapes a literal `$` (so `$${VAR}` yields the literal `${VAR}`). An undefined variable is a hard error, so a missing secret fails loudly instead of substituting an empty string.
- Wired into runPipeline as a one-line change between read and parse.
- README documents it under Secret Management, including sourcing via environmentFile (sops-nix) and, optionally, systemd LoadCredential for per-service ramfs isolation.

## Motivation

Migrating a homelab off declarative-jellyfin. Secret-bearing config values, like the SSO plugin's OidSecret, shouldn't land in the Nix store. Env-var substitution reuses the environmentFile the module already loads, stays portable (Docker, bare metal), and needs no per-field schema work.

## Behavior change

Substitution runs on every config load. An existing config containing a literal `${...}` or `$$` must escape it (`$$` for a literal `$`) after this change. Documented in the README.

## Test plan

- [x] pnpm test: new tests/lib/env-substitution.spec.ts (8 cases: single/multiple/repeated vars, both escape forms, escaped-adjacent-to-expanded, undefined-throws, no-op passthrough, process.env default)
- [x] pnpm build, ESLint, and tsc clean on the changed files

Targets v0.1.1. Any red CI on this base is pre-existing on the branch, not from this change.