### PR TITLE
fix: library update detection + complete the users test mocks

### DIFF
--- a/src/apply/library.ts
+++ b/src/apply/library.ts
@@ -27,6 +27,7 @@ export type LibraryDiff = {
 type ChangeWithValue = IChange & {
   embeddedKey?: string | number;
   value?: unknown;
+  path?: string;
 };
 
 function resolveFolderId(
@@ -40,7 +41,20 @@ function resolveFolderId(
   );
 }
 
+/**
+ * Resolve the folder Name a change belongs to. For atomized nested changes the
+ * leaf key is the changed field (e.g. "Path"), while the owning folder Name
+ * lives in the JSONPath as a `[?(@.Name=='<name>')]` filter segment, so the
+ * path is consulted first before falling back to key/embeddedKey/value.Name.
+ */
 function resolveChangeName(change: ChangeWithValue): string | undefined {
+  const path: string | undefined = change.path;
+  if (typeof path === "string") {
+    const match: RegExpExecArray | null = /@\.Name==['"]([^'"]+)['"]/.exec(
+      path,
+    );
+    if (match) return match[1];
+  }
   const key: string = change.key;
   if (key !== "" && Number.isNaN(Number(key))) return key;
   const embeddedKey: string | number | undefined = change.embeddedKey;
@@ -120,12 +134,27 @@ export function calculateLibraryDiff(
 
   logger.info(JSON.stringify(changeSet));
 
-  const addChanges: IChange[] = changeSet.filter(
-    (change: IChange) => change.type === Operation.ADD,
-  );
-  const updateChanges: ChangeWithValue[] = changeSet.filter(
-    (change: IChange) => change.type === Operation.UPDATE,
-  ) as ChangeWithValue[];
+  /**
+   * An ADD whose resolved folder Name already exists is a nested field added to
+   * an existing folder (e.g. TypeOptions or a new MetadataSavers entry) and must
+   * drive an update, not a create. Only ADDs for folder names absent from the
+   * current state are genuine creates.
+   */
+  const addChanges: IChange[] = [];
+  const updateChanges: ChangeWithValue[] = [];
+
+  for (const change of changeSet as ChangeWithValue[]) {
+    if (change.type === Operation.ADD) {
+      const name: string | undefined = resolveChangeName(change);
+      if (name && currentByName.has(name)) {
+        updateChanges.push(change);
+      } else {
+        addChanges.push(change);
+      }
+    } else if (change.type === Operation.UPDATE) {
+      updateChanges.push(change);
+    }
+  }
 
   const toCreate: VirtualFolderInfoSchema[] | undefined =
     addChanges.length > 0

--- a/src/apply/library.ts
+++ b/src/apply/library.ts
@@ -46,11 +46,15 @@ function resolveFolderId(
  * leaf key is the changed field (e.g. "Path"), while the owning folder Name
  * lives in the JSONPath as a `[?(@.Name=='<name>')]` filter segment, so the
  * path is consulted first before falling back to key/embeddedKey/value.Name.
+ *
+ * The capture uses a non-greedy `.+?` anchored on the closing `'")]` or `")]`
+ * delimiter so that folder names containing apostrophes (e.g. `Kids' Movies`)
+ * are captured in full rather than truncated at the inner quote.
  */
 function resolveChangeName(change: ChangeWithValue): string | undefined {
   const path: string | undefined = change.path;
   if (typeof path === "string") {
-    const match: RegExpExecArray | null = /@\.Name==['"]([^'"]+)['"]/.exec(
+    const match: RegExpExecArray | null = /@\.Name==['"](.+?)['"]\)\]/.exec(
       path,
     );
     if (match) return match[1];

--- a/src/mappers/library.ts
+++ b/src/mappers/library.ts
@@ -4,81 +4,51 @@ import type {
   VirtualFolderInfoSchema,
 } from "../types/schema/library";
 
+/**
+ * Drop keys whose value is `undefined`. The library diff runs against the live
+ * server config, so an omitted option must be absent rather than an explicit
+ * `undefined`, which json-diff-ts would otherwise report as a spurious change.
+ */
+function withoutUndefined<T extends Record<string, unknown>>(
+  obj: T,
+): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(obj).filter(
+      ([, value]: [string, unknown]) => value !== undefined,
+    ),
+  ) as Partial<T>;
+}
+
 export function mapVirtualFolderConfigToSchema(
   config: VirtualFolderConfig,
 ): Partial<VirtualFolderInfoSchema> {
-  /**
-   * Only PathInfos is required. Optional fields are added when defined so that
-   * omitted config keys do not become explicit `undefined` properties, which
-   * would otherwise produce spurious diffs against the current server state.
-   */
-  const LibraryOptions: Partial<LibraryOptionsSchema> = {
-    PathInfos: config.libraryOptions.pathInfos.map(
-      (pathInfo: { path: string }) => ({
-        Path: pathInfo.path,
-      }),
-    ),
-  };
+  const opts: VirtualFolderConfig["libraryOptions"] = config.libraryOptions;
 
-  if (config.libraryOptions.typeOptions !== undefined) {
-    LibraryOptions.TypeOptions = config.libraryOptions
-      .typeOptions as LibraryOptionsSchema["TypeOptions"];
-  }
-  if (config.libraryOptions.automaticallyAddToCollection !== undefined) {
-    LibraryOptions.AutomaticallyAddToCollection =
-      config.libraryOptions.automaticallyAddToCollection;
-  }
-  if (config.libraryOptions.enableChapterImageExtraction !== undefined) {
-    LibraryOptions.EnableChapterImageExtraction =
-      config.libraryOptions.enableChapterImageExtraction;
-  }
-  if (
-    config.libraryOptions.extractChapterImagesDuringLibraryScan !== undefined
-  ) {
-    LibraryOptions.ExtractChapterImagesDuringLibraryScan =
-      config.libraryOptions.extractChapterImagesDuringLibraryScan;
-  }
-  if (
-    config.libraryOptions.extractTrickplayImagesDuringLibraryScan !== undefined
-  ) {
-    LibraryOptions.ExtractTrickplayImagesDuringLibraryScan =
-      config.libraryOptions.extractTrickplayImagesDuringLibraryScan;
-  }
-  if (config.libraryOptions.enableEmbeddedEpisodeInfos !== undefined) {
-    LibraryOptions.EnableEmbeddedEpisodeInfos =
-      config.libraryOptions.enableEmbeddedEpisodeInfos;
-  }
-  if (config.libraryOptions.enableEmbeddedExtraTitles !== undefined) {
-    LibraryOptions.EnableEmbeddedExtrasTitles =
-      config.libraryOptions.enableEmbeddedExtraTitles;
-  }
-  if (config.libraryOptions.enableTrickplayImageExtraction !== undefined) {
-    LibraryOptions.EnableTrickplayImageExtraction =
-      config.libraryOptions.enableTrickplayImageExtraction;
-  }
-  if (config.libraryOptions.saveTrickplayWithMedia !== undefined) {
-    LibraryOptions.SaveTrickplayWithMedia =
-      config.libraryOptions.saveTrickplayWithMedia;
-  }
-  if (config.libraryOptions.metadataSavers !== undefined) {
-    LibraryOptions.MetadataSavers = config.libraryOptions.metadataSavers;
-  }
-  if (config.libraryOptions.saveLocalMetadata !== undefined) {
-    LibraryOptions.SaveLocalMetadata = config.libraryOptions.saveLocalMetadata;
-  }
-  if (config.libraryOptions.automaticRefreshIntervalDays !== undefined) {
-    LibraryOptions.AutomaticRefreshIntervalDays =
-      config.libraryOptions.automaticRefreshIntervalDays;
-  }
-  if (config.libraryOptions.enableRealtimeMonitor !== undefined) {
-    LibraryOptions.EnableRealtimeMonitor =
-      config.libraryOptions.enableRealtimeMonitor;
-  }
+  const libraryOptions: Partial<LibraryOptionsSchema> = withoutUndefined({
+    PathInfos: opts.pathInfos.map((pathInfo: { path: string }) => ({
+      Path: pathInfo.path,
+    })),
+    TypeOptions: opts.typeOptions as LibraryOptionsSchema["TypeOptions"],
+    AutomaticallyAddToCollection: opts.automaticallyAddToCollection,
+    EnableChapterImageExtraction: opts.enableChapterImageExtraction,
+    ExtractChapterImagesDuringLibraryScan:
+      opts.extractChapterImagesDuringLibraryScan,
+    ExtractTrickplayImagesDuringLibraryScan:
+      opts.extractTrickplayImagesDuringLibraryScan,
+    EnableEmbeddedEpisodeInfos: opts.enableEmbeddedEpisodeInfos,
+    EnableEmbeddedExtrasTitles: opts.enableEmbeddedExtraTitles,
+    EnableTrickplayImageExtraction: opts.enableTrickplayImageExtraction,
+    SaveTrickplayWithMedia: opts.saveTrickplayWithMedia,
+    MetadataSavers: opts.metadataSavers,
+    SaveLocalMetadata: opts.saveLocalMetadata,
+    AutomaticRefreshIntervalDays: opts.automaticRefreshIntervalDays,
+    EnableRealtimeMonitor: opts.enableRealtimeMonitor,
+  });
 
   return {
     Name: config.name,
     CollectionType: config.collectionType,
-    LibraryOptions: LibraryOptions as LibraryOptionsSchema,
+    LibraryOptions: libraryOptions as LibraryOptionsSchema,
   };
 }
 

--- a/src/mappers/library.ts
+++ b/src/mappers/library.ts
@@ -7,37 +7,78 @@ import type {
 export function mapVirtualFolderConfigToSchema(
   config: VirtualFolderConfig,
 ): Partial<VirtualFolderInfoSchema> {
+  /**
+   * Only PathInfos is required. Optional fields are added when defined so that
+   * omitted config keys do not become explicit `undefined` properties, which
+   * would otherwise produce spurious diffs against the current server state.
+   */
+  const LibraryOptions: Partial<LibraryOptionsSchema> = {
+    PathInfos: config.libraryOptions.pathInfos.map(
+      (pathInfo: { path: string }) => ({
+        Path: pathInfo.path,
+      }),
+    ),
+  };
+
+  if (config.libraryOptions.typeOptions !== undefined) {
+    LibraryOptions.TypeOptions = config.libraryOptions
+      .typeOptions as LibraryOptionsSchema["TypeOptions"];
+  }
+  if (config.libraryOptions.automaticallyAddToCollection !== undefined) {
+    LibraryOptions.AutomaticallyAddToCollection =
+      config.libraryOptions.automaticallyAddToCollection;
+  }
+  if (config.libraryOptions.enableChapterImageExtraction !== undefined) {
+    LibraryOptions.EnableChapterImageExtraction =
+      config.libraryOptions.enableChapterImageExtraction;
+  }
+  if (
+    config.libraryOptions.extractChapterImagesDuringLibraryScan !== undefined
+  ) {
+    LibraryOptions.ExtractChapterImagesDuringLibraryScan =
+      config.libraryOptions.extractChapterImagesDuringLibraryScan;
+  }
+  if (
+    config.libraryOptions.extractTrickplayImagesDuringLibraryScan !== undefined
+  ) {
+    LibraryOptions.ExtractTrickplayImagesDuringLibraryScan =
+      config.libraryOptions.extractTrickplayImagesDuringLibraryScan;
+  }
+  if (config.libraryOptions.enableEmbeddedEpisodeInfos !== undefined) {
+    LibraryOptions.EnableEmbeddedEpisodeInfos =
+      config.libraryOptions.enableEmbeddedEpisodeInfos;
+  }
+  if (config.libraryOptions.enableEmbeddedExtraTitles !== undefined) {
+    LibraryOptions.EnableEmbeddedExtrasTitles =
+      config.libraryOptions.enableEmbeddedExtraTitles;
+  }
+  if (config.libraryOptions.enableTrickplayImageExtraction !== undefined) {
+    LibraryOptions.EnableTrickplayImageExtraction =
+      config.libraryOptions.enableTrickplayImageExtraction;
+  }
+  if (config.libraryOptions.saveTrickplayWithMedia !== undefined) {
+    LibraryOptions.SaveTrickplayWithMedia =
+      config.libraryOptions.saveTrickplayWithMedia;
+  }
+  if (config.libraryOptions.metadataSavers !== undefined) {
+    LibraryOptions.MetadataSavers = config.libraryOptions.metadataSavers;
+  }
+  if (config.libraryOptions.saveLocalMetadata !== undefined) {
+    LibraryOptions.SaveLocalMetadata = config.libraryOptions.saveLocalMetadata;
+  }
+  if (config.libraryOptions.automaticRefreshIntervalDays !== undefined) {
+    LibraryOptions.AutomaticRefreshIntervalDays =
+      config.libraryOptions.automaticRefreshIntervalDays;
+  }
+  if (config.libraryOptions.enableRealtimeMonitor !== undefined) {
+    LibraryOptions.EnableRealtimeMonitor =
+      config.libraryOptions.enableRealtimeMonitor;
+  }
+
   return {
     Name: config.name,
     CollectionType: config.collectionType,
-    LibraryOptions: {
-      PathInfos: config.libraryOptions.pathInfos.map(
-        (pathInfo: { path: string }) => ({
-          Path: pathInfo.path,
-        }),
-      ),
-      TypeOptions: config.libraryOptions.typeOptions,
-      AutomaticallyAddToCollection:
-        config.libraryOptions.automaticallyAddToCollection,
-      EnableChapterImageExtraction:
-        config.libraryOptions.enableChapterImageExtraction,
-      ExtractChapterImagesDuringLibraryScan:
-        config.libraryOptions.extractChapterImagesDuringLibraryScan,
-      ExtractTrickplayImagesDuringLibraryScan:
-        config.libraryOptions.extractTrickplayImagesDuringLibraryScan,
-      EnableEmbeddedEpisodeInfos:
-        config.libraryOptions.enableEmbeddedEpisodeInfos,
-      EnableEmbeddedExtrasTitles:
-        config.libraryOptions.enableEmbeddedExtraTitles,
-      EnableTrickplayImageExtraction:
-        config.libraryOptions.enableTrickplayImageExtraction,
-      SaveTrickplayWithMedia: config.libraryOptions.saveTrickplayWithMedia,
-      MetadataSavers: config.libraryOptions.metadataSavers,
-      SaveLocalMetadata: config.libraryOptions.saveLocalMetadata,
-      AutomaticRefreshIntervalDays:
-        config.libraryOptions.automaticRefreshIntervalDays,
-      EnableRealtimeMonitor: config.libraryOptions.enableRealtimeMonitor,
-    } as LibraryOptionsSchema,
+    LibraryOptions: LibraryOptions as LibraryOptionsSchema,
   };
 }
 

--- a/tests/apply/library.spec.ts
+++ b/tests/apply/library.spec.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
-import { calculateLibraryDiff, applyLibrary } from "../../src/apply/library";
+import {
+  calculateLibraryDiff,
+  applyLibrary,
+  type LibraryDiff,
+} from "../../src/apply/library";
 import type { JellyfinClient } from "../../src/api/jellyfin.types";
 import type {
   LibraryConfig,
@@ -330,6 +334,89 @@ describe("apply/library", () => {
         },
       ]);
       expect(result?.toCreate).toBeUndefined();
+    });
+
+    it("should update existing folder whose name contains an apostrophe", () => {
+      const currentVirtualFolders: VirtualFolderInfoSchema[] = [
+        {
+          ItemId: "kids-movies-id",
+          Name: "Kids' Movies",
+          CollectionType: "movies",
+          LibraryOptions: {
+            PathInfos: [{ Path: "/data/kids" }],
+          } as LibraryOptionsSchema,
+        },
+      ];
+      const desired: VirtualFolderConfig[] = [
+        {
+          name: "Kids' Movies",
+          collectionType: "movies",
+          libraryOptions: {
+            pathInfos: [{ path: "/data/kids-new" }],
+          },
+        },
+      ];
+
+      const result: LibraryDiff | undefined = calculateLibraryDiff(
+        currentVirtualFolders,
+        desired,
+      );
+
+      expect(result?.toCreate).toBeUndefined();
+      expect(result?.toUpdate).toEqual([
+        {
+          id: "kids-movies-id",
+          name: "Kids' Movies",
+          libraryOptions: {
+            PathInfos: [{ Path: "/data/kids-new" }],
+          },
+        },
+      ]);
+    });
+
+    it("should not misroute a new apostrophe-named folder into an update of a prefix-matching folder", () => {
+      const currentVirtualFolders: VirtualFolderInfoSchema[] = [
+        {
+          ItemId: "kids-id",
+          Name: "Kids",
+          CollectionType: "movies",
+          LibraryOptions: {
+            PathInfos: [{ Path: "/data/kids" }],
+          } as LibraryOptionsSchema,
+        },
+      ];
+      const desired: VirtualFolderConfig[] = [
+        {
+          name: "Kids",
+          collectionType: "movies",
+          libraryOptions: {
+            pathInfos: [{ path: "/data/kids" }],
+          },
+        },
+        {
+          name: "Kids' Movies",
+          collectionType: "movies",
+          libraryOptions: {
+            pathInfos: [{ path: "/data/kids-movies" }],
+          },
+        },
+      ];
+
+      const result: LibraryDiff | undefined = calculateLibraryDiff(
+        currentVirtualFolders,
+        desired,
+      );
+
+      expect(result?.toCreate).toEqual([
+        {
+          Name: "Kids' Movies",
+          CollectionType: "movies",
+          LibraryOptions: {
+            PathInfos: [{ Path: "/data/kids-movies" }],
+          },
+        },
+      ]);
+      expect(result?.toUpdate).toBeUndefined();
     });
 
     it("should handle mixed create and existing scenarios", () => {

--- a/tests/apply/users.spec.ts
+++ b/tests/apply/users.spec.ts
@@ -34,6 +34,7 @@ vi.mock("../../src/mappers/users", () => ({
         isAdministrator?: boolean;
         loginAttemptsBeforeLockout?: number;
         maxActiveSessions?: number;
+        enableAllFolders?: boolean;
         enabledLibraries?: string[];
       },
       folderNameToIdMap?: Map<string, string>,
@@ -48,12 +49,36 @@ vi.mock("../../src/mappers/users", () => ({
       if (policy.maxActiveSessions !== undefined) {
         result.MaxActiveSessions = policy.maxActiveSessions;
       }
-      if (policy.enabledLibraries !== undefined) {
+      if (policy.enableAllFolders !== undefined) {
+        result.EnableAllFolders = policy.enableAllFolders;
+      }
+      if (
+        policy.enabledLibraries !== undefined &&
+        policy.enabledLibraries.length > 0
+      ) {
+        if (policy.enableAllFolders === undefined) {
+          result.EnableAllFolders = false;
+        }
         result.EnabledFolders = policy.enabledLibraries.map((name: string) => {
           const id: string | undefined = folderNameToIdMap?.get(name);
           if (!id) throw new Error(`Missing id for ${name}`);
           return id;
         });
+      }
+      return result;
+    },
+  ),
+  mapUserConfigToConfiguration: vi.fn(
+    (config: {
+      displayMissingEpisodes?: boolean;
+      subtitleLanguagePreference?: string;
+    }) => {
+      const result: Record<string, boolean | string> = {};
+      if (config.displayMissingEpisodes !== undefined) {
+        result.DisplayMissingEpisodes = config.displayMissingEpisodes;
+      }
+      if (config.subtitleLanguagePreference !== undefined) {
+        result.SubtitleLanguagePreference = config.subtitleLanguagePreference;
       }
       return result;
     },

--- a/tests/mappers/users.spec.ts
+++ b/tests/mappers/users.spec.ts
@@ -405,7 +405,7 @@ describe("mappers/users", () => {
       const config: UserPolicyConfig = { enabledLibraries: ["Movies"] };
 
       expect(() => mapUserPolicyConfigToSchema(config, folderMap)).toThrowError(
-        /no matching library ids/,
+        /not found while resolving enabledLibraries/,
       );
     });
 


### PR DESCRIPTION
Fixes the pre-existing test failures on `v0.1.1`. Two real bugs in the library apply, plus three broken tests in the users suite.

## Library: updates to existing folders were never applied (real bug)

`calculateLibraryDiff` diffs the virtual-folders array with `embeddedObjKeys: { ".": "Name" }` and `.atomize()`. For a nested change (e.g. a `PathInfos[i].Path` edit) the atomized change looks like:

```
{ type: "UPDATE", key: "Path", value: "/b",
  path: "$.$root[?(@.Name=='Movies')].LibraryOptions.PathInfos[0].Path" }
```

`resolveChangeName` returned `change.key` ("Path", the leaf field) instead of the folder name, so the update never matched a folder, `toUpdate` stayed empty, and the function returned `undefined`. Library option/path/typeOptions changes silently didn't apply.

Two fixes in `src/apply/library.ts`:
- `resolveChangeName` now reads the folder Name from the change `path` (`[?(@.Name=='<name>')]`) first, then falls back to key/embeddedKey/value.Name. The regex captures to the closing `')]` so names with apostrophes (`Kids' Movies`) are handled, with tests.
- ADD/UPDATE classification: an atomized ADD whose resolved folder name already exists (a nested field added to an existing folder, e.g. `TypeOptions`) now drives an update rather than a create. ADDs for folder names absent from current remain creates.

And in `src/mappers/library.ts`: `mapVirtualFolderConfigToSchema` now guards optional fields instead of emitting them as explicit `undefined`. The undefined keys were producing a spurious diff that reported a change for identical state (the "matching locations" case). This also matches how the system/encoding/networking mappers already work.

## Users: three broken tests (test-only)

- `tests/mappers/users.spec.ts`: the assertion expected `/no matching library ids/`, but the code throws `Library '<name>' not found while resolving enabledLibraries`. The code is correct; updated the regex.
- `tests/apply/users.spec.ts`: the `vi.mock` of `../../src/mappers/users` omitted the `mapUserConfigToConfiguration` export the code under test calls, so two tests errored on the missing mock. Added it, mirroring the real mapper. Production code untouched.

## Result

- `pnpm test`: 424 passing. The 2 remaining failures are `apply/system.spec.ts` TrickplayOptions cases, which are out of scope here and fixed in the config-coverage PR (#68) that rewrites the system diff. With both PRs, the suite is fully green.

Targets v0.1.1.