### PR TITLE
fix: gracefully handle missing plugin configuration

### DIFF
--- a/src/apply/plugins.ts
+++ b/src/apply/plugins.ts
@@ -13,6 +13,19 @@ import type {
 import { ChangeSetBuilder } from "../lib/changeset";
 import { applyChangeset, diff, type IChange } from "json-diff-ts";
 
+function isPluginConfigurationMissingError(error: unknown): boolean {
+  if (typeof error === "object" && error !== null && "response" in error) {
+    const responseStatus: number | undefined = (
+      error as {
+        response?: { status?: number };
+      }
+    ).response?.status;
+    if (responseStatus === 404) return true;
+  }
+
+  return error instanceof Error && /failed:\s*404$/.test(error.message);
+}
+
 export function calculatePluginsToInstall(
   installedPlugins: PluginInfoSchema[],
   desired: PluginConfigList,
@@ -55,10 +68,15 @@ export async function getPluginConfigurationSchemaByName(
 
   for (const pluginInfo of current) {
     if (pluginInfo.Id && pluginInfo.Name) {
-      pluginConfigurationSchemaByName.set(pluginInfo.Name, {
-        id: pluginInfo.Id,
-        configuration: await client.getPluginConfiguration(pluginInfo.Id),
-      });
+      try {
+        pluginConfigurationSchemaByName.set(pluginInfo.Name, {
+          id: pluginInfo.Id,
+          configuration: await client.getPluginConfiguration(pluginInfo.Id),
+        });
+      } catch (error) {
+        if (isPluginConfigurationMissingError(error)) continue;
+        throw error;
+      }
     }
   }
 

--- a/tests/apply/plugins.spec.ts
+++ b/tests/apply/plugins.spec.ts
@@ -395,6 +395,40 @@ describe("getPluginConfigurationSchemaByName", () => {
     });
     expect(getPluginConfigurationSpy).toHaveBeenCalledTimes(1);
   });
+
+  it("should ignore missing plugin configuration responses", async () => {
+    // Arrange
+    const installedPlugins: PluginInfoSchema[] = [
+      { Name: "Fanart", Id: "fanart-id" } as PluginInfoSchema,
+    ];
+    getPluginConfigurationSpy.mockRejectedValueOnce(
+      new Error("GET /Plugins/fanart-id/Configuration failed: 404"),
+    );
+
+    // Act
+    const result: Map<string, PluginConfigurationSchema> =
+      await getPluginConfigurationSchemaByName(mockClient, installedPlugins);
+
+    // Assert
+    expect(result.size).toBe(0);
+    expect(getPluginConfigurationSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("should rethrow plugin configuration errors other than 404", async () => {
+    // Arrange
+    const installedPlugins: PluginInfoSchema[] = [
+      { Name: "Fanart", Id: "fanart-id" } as PluginInfoSchema,
+    ];
+    const error: Error = new Error(
+      "GET /Plugins/fanart-id/Configuration failed: 500",
+    );
+    getPluginConfigurationSpy.mockRejectedValueOnce(error);
+
+    // Act & Assert
+    await expect(
+      getPluginConfigurationSchemaByName(mockClient, installedPlugins),
+    ).rejects.toThrow(error);
+  });
 });
 
 describe("calculatePluginConfigurationDiff", () => {


### PR DESCRIPTION
## Summary

- skip installed plugins whose configuration endpoint returns HTTP 404
- continue processing other plugins without configuration support
- preserve failures for every non-404 response

## Root cause

Some installed Jellyfin plugins do not expose a configuration endpoint. Jellarr treated that expected 404 as fatal and stopped applying the remaining configuration.

Fixes #53.

## Validation

- `nix fmt`
- `nix build .#`
- plugin Vitest suite: 35 tests passed
- Nix formatting, linting, and module-type checks
