### PR TITLE
nix: allow overriding the jellarr package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -38,6 +38,9 @@
           {
             formatting = treefmtFormatEval.config.build.check inputs.self;
             linting = treefmtLintEval.config.build.check inputs.self;
+            module-package-override = import ./nix/tests/module {
+              inherit nixpkgs pkgs system;
+            };
             module-types = import ./nix/tests/module/types {inherit pkgs;};
           }
           // import ./nix/tests/integration {inherit pkgs;};

--- a/nix/module/config.nix
+++ b/nix/module/config.nix
@@ -10,8 +10,6 @@
 
   types = import ./types {inherit lib;};
   processedConfig = types.root.mkConfig cfg.config;
-
-  pkg = pkgs.callPackage ../package.nix {};
 in {
   config = lib.mkMerge [
     (lib.mkIf cfg.enable {
@@ -43,7 +41,7 @@ in {
             '';
           serviceConfig = {
             EnvironmentFile = lib.optional (cfg.environmentFile != null) cfg.environmentFile;
-            ExecStart = lib.getExe pkg;
+            ExecStart = lib.getExe cfg.package;
             Group = cfg.group;
             Type = "oneshot";
             User = cfg.user;

--- a/nix/module/options.nix
+++ b/nix/module/options.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  pkgs,
   ...
 }: let
   types = import ./types {inherit lib;};
@@ -77,6 +78,13 @@ in {
         Environment file as defined in {manpage}`systemd.exec(5)`.
       '';
       type = lib.types.nullOr lib.types.path;
+    };
+
+    package = lib.mkOption {
+      default = pkgs.callPackage ../package.nix {};
+      defaultText = lib.literalExpression "pkgs.callPackage ../package.nix {}";
+      description = "Package to run for the jellarr service.";
+      type = lib.types.package;
     };
 
     group = lib.mkOption {

--- a/nix/tests/module/default.nix
+++ b/nix/tests/module/default.nix
@@ -1,0 +1,32 @@
+{
+  nixpkgs,
+  pkgs,
+  system,
+}: let
+  customPackage = pkgs.writeShellScriptBin "custom-jellarr" ''
+    exit 0
+  '';
+  evaluated = nixpkgs.lib.nixosSystem {
+    inherit system;
+    modules = [
+      ../../module
+      {
+        services.jellarr = {
+          enable = true;
+          package = customPackage;
+          config = {
+            version = 1;
+            base_url = "http://localhost:8096";
+          };
+        };
+        system.stateVersion = "26.05";
+      }
+    ];
+  };
+  expected = nixpkgs.lib.getExe customPackage;
+  actual = evaluated.config.systemd.services.jellarr.serviceConfig.ExecStart;
+in
+  assert actual == expected;
+    pkgs.runCommand "jellarr-module-package-override" {} ''
+      touch $out
+    ''


### PR DESCRIPTION
## Summary

- add `services.jellarr.package`
- use the configured package for the systemd service `ExecStart`
- keep the in-tree package as the default
- add a NixOS module evaluation check proving that a custom package controls `ExecStart`

## Impact

NixOS users can run a patched or independently packaged Jellarr build without replacing the module itself.

## Validation

- `nix fmt`
- default package build
- Nix formatting, linting, and module-type checks
- package-override evaluation check on `aarch64-darwin`
- package-override evaluation check on `x86_64-linux`
- all-system flake evaluation
